### PR TITLE
Optimize bulk ingest.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] - 2018-04-05
+
+### Added
+
+- Optimized bulk/batch ingest for fhir-ingest
+
 ## [4.0.2] - 2018-03-30
 
 ### Fixed

--- a/lib/commands/fhir.js
+++ b/lib/commands/fhir.js
@@ -2,7 +2,7 @@
 
 const program = require('commander');
 const querystring = require('querystring');
-const { get, post, del, put } = require('../fhir');
+const { get, post, del } = require('../fhir');
 const options = require('../common-options');
 const print = require('../print');
 const read = require('../read');
@@ -17,7 +17,7 @@ function getAccount (options) {
 async function search (type, query, options) {
   const account = getAccount(options);
   const result = [];
-  const limit = options.limit || Number.MAX_SAFE_INTEGER;
+  const limit = options.limit;
 
   if (query) {
     query.pageSize = limit;
@@ -76,7 +76,7 @@ async function searchAndDelete (dataset, type, options) {
 
 options(program, 'fhir <type> [query]')
   .description('Search for FHIR resources.')
-  .option('--limit <N>', 'Limit the result set to N')
+  .option('--limit <N>', 'Limit the result set to N', 1000)
   .option('--dataset <datasetID>', 'Filter by data set id')
   .action(async (type, query, options) => {
     if (query) {
@@ -109,46 +109,26 @@ function setDataset (data, options) {
   }
 }
 
-function getUrlForResource (data, options) {
-  if (!data.resourceType) {
-    throw new Error('missing ResourceType on FHIR object');
-  }
-
-  const account = getAccount(options);
-  const idUrlPart = data.id ? `/${data.id}` : '';
-  return `${account}/dstu3/${data.resourceType}${idUrlPart}`;
-}
-
-async function createOrUpdate (data, options) {
-  const url = getUrlForResource(data, options);
-  setDataset(data, options);
-  const methodToUse = data.id ? put : post;
-  const response = await methodToUse(options, url, data);
-  return {
-    id: response.headers['location'] ? response.headers['location'].split('/').pop() : data.id,
-    resourceType: data.resourceType
-  };
-}
-
-async function collect (f, data, options) {
-  if (Array.isArray(data)) {
-    let result = [];
-    const chunks = _.chunk(data, 10);
-    for (const chunk of chunks) {
-      result = result.concat(await Promise.all(chunk.map(resource => f(resource, options))));
-    }
-    return result;
-  } else {
-    return f(data, options);
-  }
-}
-
 options(program, 'fhir-ingest')
   .description('Create or update one or more FHIR resources. The resources are read from stdin.')
   .option('--dataset <datasetID>', 'Tag the resource with the given datasetID')
+  .option('--chunk <chunkSize>', 'Set the chunk size to use with batching the requests', 100)
   .action(async (options) => {
+    const account = getAccount(options);
+    const url = `${account}/dstu3`;
     const data = await read(options);
-    const result = await collect(createOrUpdate, data, options);
+    data.forEach(resource => setDataset(resource, options));
+    const chunks = _.chunk(data, options.chunk);
+    let result = [];
+    for (const chunk of chunks) {
+      const batch = {
+        type: 'collection',
+        resourceType: 'Bundle',
+        entry: chunk.map(resource => ({resource}))
+      };
+      const response = await post(options, url, batch);
+      result.push(...response.data.entry);
+    }
     print(result, options);
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/cli",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "CLI for interacting with the LifeOmic PMP API.",
   "main": "lo.js",
   "author": "LifeOmic <development@lifeomic.com>",


### PR DESCRIPTION
Also changed the default limit for the `fhir` command
to be 1000 rater than infinite. This is a safer default
so that people don't do crazy things like query all the data.