### PR TITLE
Implement support for client supplied ids when uploading files

### DIFF
--- a/lib/commands/file.js
+++ b/lib/commands/file.js
@@ -96,6 +96,7 @@ const filesUpload = async (file, dataset, options) => {
     try {
       if (fileSize > MULTIPART_MIN_SIZE) {
         const response = await post(options, UPLOADS_URL, {
+          id: options.id,
           name: fileName,
           datasetId: dataset,
           overwrite: options.overwrite
@@ -105,6 +106,7 @@ const filesUpload = async (file, dataset, options) => {
         console.log(chalk.green(`Upload complete: ${fileName}, ID: ${response.data.id}`));
       } else {
         const response = await post(options, FILES_URL, {
+          id: options.id,
           name: fileName,
           datasetId: dataset,
           overwrite: options.overwrite
@@ -159,6 +161,7 @@ options(program, 'files-upload <file> <datasetID>')
   .option('--recursive', 'If <file> is a directory, uploads all files in the directory and any sub directories.')
   .option('--overwrite', 'Overwrite any existing files in the dataset.')
   .option('--delete-after-upload', 'Delete each file after it is successfully uploaded.')
+  .option('--id <UUID>', 'Client supplied id. Must be a valid v4 UUID.')
   .description('Upload a local file or directory of files to a dataset.')
   .action(filesUpload);
 

--- a/test/unit/commands/fhir-test.js
+++ b/test/unit/commands/fhir-test.js
@@ -35,7 +35,7 @@ test.afterEach.always(t => {
   postStub.reset();
   delStub.reset();
   putStub.reset();
-  printSpy.reset();
+  printSpy.resetHistory();
   readStub.reset();
   callback = null;
 });

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -21,8 +21,10 @@ const CONFIG_FIXTURE = {
 };
 
 const _ORIGINAL_LIFEOMIC_ENVIRONMENT = process.env.LIFEOMIC_ENVIRONMENT;
+const originalConfig = config.all;
 test.after(t => {
   process.env.LIFEOMIC_ENVIRONMENT = _ORIGINAL_LIFEOMIC_ENVIRONMENT;
+  config.all = originalConfig;
 });
 
 test.beforeEach(t => {


### PR DESCRIPTION
Also fixed the tests so they don't blap over the users
original config and break their installed CLI. Also fixed
some incorrect stub resetting that was causing state from one
test to bleed over into another.