### PR TITLE
Support json-lines input for fhir-ingest

### DIFF
--- a/lib/commands/fhir.js
+++ b/lib/commands/fhir.js
@@ -6,10 +6,11 @@ const querystring = require('querystring');
 const { get, post, del } = require('../fhir');
 const options = require('../common-options');
 const print = require('../print');
-const read = require('../read');
+const stdin = require('../stdin');
 const config = require('../config');
 const chunk = require('lodash/chunk');
 const url = require('url');
+const StreamValues = require('stream-json/streamers/StreamValues');
 
 function getAccount (options) {
   const environment = config.getEnvironment();
@@ -88,28 +89,82 @@ function setDataset (data, options) {
   }
 }
 
+function fhirPost (options, resources) {
+  const account = getAccount(options);
+  const url = `${account}/dstu3`;
+  resources.forEach(resource => setDataset(resource, options));
+  const batch = {
+    type: 'collection',
+    resourceType: 'Bundle',
+    entry: resources.map(resource => ({resource}))
+  };
+  return post(options, url, batch);
+}
+
+async function batchUpload (options, resources) {
+  const chunks = chunk(resources, options.chunk);
+  for (const chunk of chunks) {
+    const response = await fhirPost(options, chunk);
+    print(response.data.entry, options);
+
+    const failed = response.data.entry
+      .filter(r => r.response.status !== '201' && r.response.status !== '200')
+      .map(r => r.response.outcome);
+
+    if (failed.length > 0) {
+      throw new Error(`Error when ingesting resources: ${JSON.stringify(failed)}`);
+    }
+  }
+}
+
+async function ingest (options) {
+  let resources = [];
+
+  const pipeline = stdin().pipe(StreamValues.withParser());
+
+  return new Promise((resolve, reject) => {
+    pipeline.on('data', async ({ value }) => {
+      if (Array.isArray(value)) {
+        resources = resources.concat(value);
+      } else {
+        resources.push(value);
+      }
+
+      if (resources.length >= options.chunk) {
+        try {
+          const payload = resources.slice();
+          resources = [];
+          await batchUpload(options, payload);
+        } catch (err) {
+          pipeline.destroy(err);
+          reject(err);
+        }
+      }
+    });
+
+    pipeline.on('error', (err) => reject(err));
+    pipeline.on('end', async () => {
+      if (resources.length > 0) {
+        try {
+          const payload = resources.slice();
+          resources = [];
+          await batchUpload(options, payload);
+        } catch (err) {
+          pipeline.destroy(err);
+          reject(err);
+          return;
+        }
+      }
+      resolve();
+    });
+  });
+}
+
 options(program, 'fhir-ingest')
   .description('Create or update one or more FHIR resources. The resources are read from stdin.')
   .option('--dataset <datasetID>', 'Tag the resource with the given datasetID')
   .option('--chunk <chunkSize>', 'Set the chunk size to use with batching the requests', 100)
-  .action(async (options) => {
-    const account = getAccount(options);
-    const url = `${account}/dstu3`;
-    const data = await read(options);
-    data.forEach(resource => setDataset(resource, options));
-    const chunks = chunk(data, options.chunk);
-    const result = [];
-    for (const chunk of chunks) {
-      const batch = {
-        type: 'collection',
-        resourceType: 'Bundle',
-        entry: chunk.map(resource => ({resource}))
-      };
-      const response = await post(options, url, batch);
-      result.push(...response.data.entry);
-    }
-    print(result, options);
-  });
+  .action(ingest);
 
 options(program, 'fhir-delete <type> <id>')
   .description('Delete a FHIR resource by type and id.')

--- a/lib/stdin.js
+++ b/lib/stdin.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = () => {
+  return process.stdin;
+};

--- a/package.json
+++ b/package.json
@@ -37,12 +37,14 @@
     "prettyjson": "^1.2.1",
     "queue": "^4.4.2",
     "recursive-readdir": "^2.2.2",
-    "stoppable": "^1.0.5"
+    "stoppable": "^1.0.5",
+    "stream-json": "^1.1.1"
   },
   "devDependencies": {
     "@lifeomic/eslint-plugin-node": "^1.1.1",
     "ava": "^0.25.0",
     "eslint": "^4.19.1",
+    "memory-streams": "^0.1.3",
     "pkg": "^4.3.3",
     "proxyquire": "^2.0.1",
     "sinon": "^4.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2073,7 +2073,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -2735,6 +2735,12 @@ md5-hex@^2.0.0:
 md5-o-matic@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
+
+memory-streams@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/memory-streams/-/memory-streams-0.1.3.tgz#d9b0017b4b87f1d92f55f2745c9caacb1dc93ceb"
+  dependencies:
+    readable-stream "~1.0.2"
 
 meow@^3.7.0:
   version "3.7.0"
@@ -3445,6 +3451,15 @@ readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readable-stream@~1.0.2:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
 readdirp@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
@@ -3904,6 +3919,16 @@ stoppable@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/stoppable/-/stoppable-1.0.6.tgz#21f7f933f884f64947c5ad3eb6dd7413cb4531ca"
 
+stream-chain@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/stream-chain/-/stream-chain-2.0.3.tgz#9155237a719c8bb2de883c2d1af66d1546f910c9"
+
+stream-json@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stream-json/-/stream-json-1.1.1.tgz#9f3536daa894521cd65967c6c6b087c2be75cc43"
+  dependencies:
+    stream-chain "^2.0.3"
+
 stream-meter@1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/stream-meter/-/stream-meter-1.0.4.tgz#52af95aa5ea760a2491716704dbff90f73afdd1d"
@@ -3924,6 +3949,10 @@ string-width@^1.0.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
 string_decoder@~1.1.1:
   version "1.1.1"


### PR DESCRIPTION
Multiple JSON objects on the same line or white space
separate also works, as does arrays.

This makes fhir-ingest work for arbitrarily large inputs
because it no longer reads the input all into memory before
ingesting it.