### PR TITLE
Implement backpressure on FHIR ingest

### DIFF
--- a/lib/cmds/fhir_cmds/ingest.js
+++ b/lib/cmds/fhir_cmds/ingest.js
@@ -4,6 +4,7 @@ const { post, getAccount } = require('../../fhir');
 const print = require('../../print');
 const stdin = require('../../stdin');
 const _chunk = require('lodash/chunk');
+const {chain} = require('stream-chain');
 const StreamValues = require('stream-json/streamers/StreamValues');
 
 function setDataset (data, options) {
@@ -66,10 +67,10 @@ exports.builder = yargs => {
 exports.handler = async argv => {
   let resources = [];
 
-  const pipeline = stdin().pipe(StreamValues.withParser());
-
-  return new Promise((resolve, reject) => {
-    pipeline.on('data', async ({ value }) => {
+  const pipeline = chain([
+    stdin(),
+    StreamValues.withParser(),
+    async ({value}) => {
       if (Array.isArray(value)) {
         resources = resources.concat(value);
       } else {
@@ -77,19 +78,16 @@ exports.handler = async argv => {
       }
 
       if (resources.length >= argv.chunk) {
-        try {
-          const payload = resources.slice();
-          resources = [];
-          await batchUpload(argv, payload);
-        } catch (err) {
-          pipeline.destroy(err);
-          reject(err);
-        }
+        const payload = resources.slice();
+        resources = [];
+        await batchUpload(argv, payload);
       }
-    });
+    }
+  ]);
 
-    pipeline.on('error', (err) => reject(err));
-    pipeline.on('end', async () => {
+  return new Promise((resolve, reject) => {
+    pipeline.output.on('error', (err) => reject(err));
+    pipeline.output.on('end', async () => {
       if (resources.length > 0) {
         try {
           const payload = resources.slice();

--- a/package.json
+++ b/package.json
@@ -37,8 +37,9 @@
     "queue": "^4.4.2",
     "recursive-readdir": "^2.2.2",
     "stoppable": "^1.0.5",
-    "yargs": "^12.0.1",
-    "stream-json": "^1.1.1"
+    "stream-chain": "^2.0.3",
+    "stream-json": "^1.1.1",
+    "yargs": "^12.0.1"
   },
   "devDependencies": {
     "@lifeomic/eslint-plugin-node": "^1.1.1",

--- a/test/unit/commands/fhir-test.js
+++ b/test/unit/commands/fhir-test.js
@@ -4,7 +4,7 @@ const yargs = require('yargs');
 const sinon = require('sinon');
 const test = require('ava');
 const proxyquire = require('proxyquire');
-const streams = require('memory-streams');
+const fs = require('fs');
 
 const getStub = sinon.stub();
 const postStub = sinon.stub();
@@ -44,11 +44,6 @@ test.afterEach.always(t => {
   stdinStub.reset();
   callback = null;
 });
-
-function mockStdin (data) {
-  const result = new streams.ReadableStream(data);
-  return result;
-}
 
 test.serial.cb('The "fhir" command should list fhir resources', t => {
   const res = {data: { entry: [] }};
@@ -90,8 +85,8 @@ test.serial.cb('The "fhir-ingest" command should update a fhir resource', t => {
   const res = {data: {entry: [{response: {location: '/account/dstu3/Patient/1234', status: '200'}}]}};
   postStub.returns(res);
 
-  const data = [{resourceType: 'Patient', id: '1234'}];
-  const stdin = mockStdin(JSON.stringify(data) + '\n');
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  const stdin = fs.createReadStream(`${__dirname}/fhir/array.json`);
   stdinStub.returns(stdin);
 
   callback = () => {
@@ -117,15 +112,14 @@ test.serial.cb('The "fhir-ingest" command should update a fhir resource', t => {
 
   yargs.command(ingest)
     .parse('ingest');
-  stdin.push(null);
 });
 
 test.serial.cb('The "fhir-ingest" with dataset command should update a fhir resource with dataset', t => {
   const res = {data: {entry: [{response: {location: '/account/dstu3/Patient/1234', status: '200'}}]}};
   postStub.returns(res);
 
-  const data = [{resourceType: 'Patient', id: '1234'}];
-  const stdin = mockStdin(JSON.stringify(data) + '\n');
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  const stdin = fs.createReadStream(`${__dirname}/fhir/object.json`);
   stdinStub.returns(stdin);
 
   callback = () => {
@@ -159,7 +153,6 @@ test.serial.cb('The "fhir-ingest" with dataset command should update a fhir reso
 
   yargs.command(ingest)
     .parse('ingest --dataset abc');
-  stdin.push(null);
 });
 
 test.serial.cb('The "fhir-delete" command should delete a fhir resource', t => {

--- a/test/unit/commands/fhir/array.json
+++ b/test/unit/commands/fhir/array.json
@@ -1,0 +1,6 @@
+[
+  {
+    "resourceType": "Patient",
+    "id": "1234"
+  }
+]

--- a/test/unit/commands/fhir/object.json
+++ b/test/unit/commands/fhir/object.json
@@ -1,0 +1,1 @@
+{"resourceType": "Patient", "id": "1234"}


### PR DESCRIPTION
This makes it so we don't end up doing a bunch of
POST requests in parallel and instead do them one at
a time without running the risk of reading it all into
memory.