### PR TITLE
Properly handle errors in FHIR ingest.

### DIFF
--- a/lib/cmds/fhir_cmds/ingest.js
+++ b/lib/cmds/fhir_cmds/ingest.js
@@ -86,7 +86,7 @@ exports.handler = async argv => {
   ]);
 
   return new Promise((resolve, reject) => {
-    pipeline.output.on('error', (err) => reject(err));
+    pipeline.on('error', (err) => reject(err));
     pipeline.output.on('end', async () => {
       if (resources.length > 0) {
         try {


### PR DESCRIPTION
Discovered this problem while testing the same change to task-service-container.