### PR TITLE
Make project a required option for search-delete

### DIFF
--- a/lib/cmds/fhir_cmds/search-del.js
+++ b/lib/cmds/fhir_cmds/search-del.js
@@ -4,17 +4,17 @@ const querystring = require('querystring');
 const { del, getAccount } = require('../../fhir');
 const chalk = require('chalk');
 
-exports.command = 'search-delete <type>';
-exports.desc = 'Delete all FHIR resources of a certain type that match an optional query';
+exports.command = 'search-delete <type> <project>';
+exports.desc = 'Delete all FHIR resources of a certain type in a project that match an optional query';
 exports.builder = yargs => {
   yargs.positional('type', {
     describe: 'The FHIR resource type.',
     type: 'string'
+  }).positional('project', {
+    describe: 'The ID of the project to delete from.',
+    type: 'string'
   }).option('query', {
     describe: 'The FHIR query',
-    type: 'string'
-  }).option('dataset', {
-    describe: 'Filter by dataset ID',
     type: 'string'
   });
 };
@@ -26,9 +26,7 @@ exports.handler = async argv => {
     argv.query = {};
   }
 
-  if (argv.dataset) {
-    argv.query['_tag'] = `http://lifeomic.com/fhir/dataset|${argv.dataset}`;
-  }
+  argv.query['_tag'] = `http://lifeomic.com/fhir/dataset|${argv.project}`;
 
   const account = getAccount(argv);
   const url = `${account}/dstu3/${argv.type}?${querystring.stringify(argv.query)}`;

--- a/test/unit/commands/fhir-test.js
+++ b/test/unit/commands/fhir-test.js
@@ -170,10 +170,10 @@ test.serial.cb('The "fhir-delete" command should delete a fhir resource', t => {
 
 test.serial.cb('The "fhir-search-delete" command should delete all fhir resource of a certain type matching a query and dataset', t => {
   yargs.command(searchDel)
-    .parse('search-delete Patient --dataset dataset-id --query name=John');
+    .parse('search-delete Patient project-id --query name=John');
 
   t.is(delStub.callCount, 1);
-  t.is(delStub.getCall(0).args[1], 'account/dstu3/Patient?name=John&_tag=http%3A%2F%2Flifeomic.com%2Ffhir%2Fdataset%7Cdataset-id');
+  t.is(delStub.getCall(0).args[1], 'account/dstu3/Patient?name=John&_tag=http%3A%2F%2Flifeomic.com%2Ffhir%2Fdataset%7Cproject-id');
   t.is(printSpy.callCount, 0);
   t.end();
 });


### PR DESCRIPTION
The old `--dataset` option was dangerous because if you forgot
it you'd end up deleting all data in all projects. Also,
it was misnamed and should have been `--project`. This change
adds a bit of safety to prevent someone from accidentally
deleting all their data.