### PR TITLE
retry failed FHIR requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [??] - 2018-1016
+
+#### Fixed
+
+- Renamed the `--dataset` option on `lo fhir ingest` to `--project`
+  to match the other `fhir` commands.
+
+- Added retries on `5xx` errors to the `fhir` commands.
+
 ## [6.9.0] - 2018-10-12
 
 #### Added

--- a/lib/cmds/fhir_cmds/ingest.js
+++ b/lib/cmds/fhir_cmds/ingest.js
@@ -8,7 +8,7 @@ const {chain} = require('stream-chain');
 const StreamValues = require('stream-json/streamers/StreamValues');
 
 function setDataset (data, options) {
-  if (options.dataset) {
+  if (options.project) {
     if (data.meta) {
       if (data.meta.tag) {
         data.meta.tag = data.meta.tag.filter(x => x.system !== 'http://lifeomic.com/fhir/dataset');
@@ -19,7 +19,7 @@ function setDataset (data, options) {
       data.meta = {tag: []};
     }
 
-    data.meta.tag.push({system: 'http://lifeomic.com/fhir/dataset', code: options.dataset});
+    data.meta.tag.push({system: 'http://lifeomic.com/fhir/dataset', code: options.project});
   }
 }
 
@@ -58,8 +58,8 @@ exports.builder = yargs => {
     describe: 'Set the chunk size to use with batching the requests',
     type: 'integer',
     default: 100
-  }).option('dataset', {
-    describe: 'Tag the resource with the given dataset ID',
+  }).option('project', {
+    describe: 'Tag the resource with the given project ID',
     type: 'string'
   });
 };

--- a/lib/fhir.js
+++ b/lib/fhir.js
@@ -6,7 +6,28 @@ const config = require('./config');
 const { name, version } = require('../package.json');
 const tokenProvider = require('./interceptor/tokenProvider');
 
-axiosRetry(axios, { retries: 3 });
+// These retry settings will retry more times (5 vs 3),
+// with an exponential backoff (rather than no delay)
+// and will retry POST (normally POST requests are not
+// retried since they are not idempotent, but in FHIR
+// we use POST for searches and ingest, both of which are
+// idempotent (assuming ingest uses client supplied ids
+// which it usually does.), and will retry timeouts.
+// This all makes ingest in particular much more reliable,
+// which is important when ingesting large datasets.
+const shouldRetry = error => {
+  return axiosRetry.isNetworkError(error) ||
+    axiosRetry.isRetryableError(error) ||
+    error.code === 'ECONNABORTED';
+};
+axiosRetry(axios, {
+  retries: 5,
+  retryDelay: axiosRetry.exponentialDelay,
+  retryCondition: e => shouldRetry,
+  shouldResetTimeout: true
+});
+axios.defaults.timeout = 16000; // 16 seconds
+
 axios.defaults.headers.common['User-Agent'] = `${name}/${version}`;
 
 function request (options) {

--- a/test/unit/commands/fhir-test.js
+++ b/test/unit/commands/fhir-test.js
@@ -114,7 +114,7 @@ test.serial.cb('The "fhir-ingest" command should update a fhir resource', t => {
     .parse('ingest');
 });
 
-test.serial.cb('The "fhir-ingest" with dataset command should update a fhir resource with dataset', t => {
+test.serial.cb('The "fhir-ingest" with project command should update a fhir resource with dataset', t => {
   const res = {data: {entry: [{response: {location: '/account/dstu3/Patient/1234', status: '200'}}]}};
   postStub.returns(res);
 
@@ -152,7 +152,7 @@ test.serial.cb('The "fhir-ingest" with dataset command should update a fhir reso
   };
 
   yargs.command(ingest)
-    .parse('ingest --dataset abc');
+    .parse('ingest --project abc');
 });
 
 test.serial.cb('The "fhir-delete" command should delete a fhir resource', t => {


### PR DESCRIPTION
Also rename the `--dataset` argument to `--project` in `fhir ingest`
to match all the other `fhir` commands.