### PR TITLE
handle errors that have null string representations

### DIFF
--- a/lo.js
+++ b/lo.js
@@ -17,8 +17,10 @@ function handleError (msg, err) {
       console.log(chalk.red(`Request failed with status: ${err.response.status}, body:`));
       console.log(chalk.red(JSON.stringify(err.response.data, null, 2)));
     }
-  } else {
+  } else if (msg) {
     console.error(chalk.red(msg));
+  } else {
+    console.error(chalk.red(err));
   }
   process.exitCode = 1;
 }


### PR DESCRIPTION
I hit case where an error got thrown with no message (i.e. err.toString() returned null). I wasn't able to reproduce it to figure out what the error actually was, but this change here should improve the error reporting in this case.