### PR TITLE
improve setup and auth usability

### DIFF
--- a/lib/cmds/auth.js
+++ b/lib/cmds/auth.js
@@ -49,7 +49,7 @@ exports.handler = async argv => {
       process.exit(1);
     }
   } else {
-    if (config.get(`${environment}.defaults.useClientCredentials` || config.get(`${environment}.defaults.useApiKey`))) {
+    if (config.get(`${environment}.defaults.useClientCredentials`) || config.get(`${environment}.defaults.useApiKey`)) {
       console.log(chalk.red(`auth command is not allowed for client credentials or API key.`));
     } else {
       login();

--- a/lib/cmds/setup.js
+++ b/lib/cmds/setup.js
@@ -14,13 +14,14 @@ exports.handler = async argv => {
       type: 'list',
       name: 'environment',
       message: 'Pick a LifeOmic environment',
-      choices: ['dev', 'prod-us'],
+      choices: config.get(`dev.userPooldId`) ? ['dev', 'prod-us'] : ['prod-us'],
       default: config.get(`defaults.environment`)
     },
     {
       type: 'input',
       name: 'account',
-      message: 'Specify a default LifeOmic account to use: ',
+      message: 'Specify a default organization account id to use: ',
+      validate: input => input.match(/^([a-z0-9]{1,16})$/) ? true : `${input} is not a valid account id`,
       default: a => config.get(`${a.environment}.defaults.account`)
     },
     {


### PR DESCRIPTION
- make it more clear that the account name is for the organization rather than the user
- add account name validation which will atleast reject email addresses
- don't allow auth when api key is in user
- hide dev environment choice when it isn't setup