### PR TITLE
Set maxContentLength for multi part uploads

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -190,7 +190,8 @@ module.exports.multipartUpload = async function (options, uploadId, fileName, fi
             headers: {
               'Content-Length': size,
               'Content-MD5': verifyStream.contentMD5
-            }
+            },
+            maxContentLength: size
           });
           const diff = process.hrtime(time);
           bar.increment(size);


### PR DESCRIPTION
Not fully verified yet, but Swee was trying to upload a 120GB file.  This resulted in a part size that was bigger than the axios default.  Setting the option to the part size seems to allow things to work. 