### PR TITLE
Warn rather than erroring out if OAuth state is missing.

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -66,7 +66,9 @@ function showLogin (environment, state, verifier) {
 
     const appName = process.platform === 'darwin' || process.platform === 'win32' ? null : 'xdg-open';
 
-    open(`${config.get(`${environment}.apiUrl`)}/v1/oauth/authorize?${querystring.stringify(opts)}`, appName, (e) => {
+    const url = `${config.get(`${environment}.apiUrl`)}/v1/oauth/authorize?${querystring.stringify(opts)}`;
+    debug(`opening ${url}`);
+    open(url, appName, (e) => {
       if (e) {
         console.log(chalk.red('Failed to open browser.', e));
         process.exit(1);
@@ -110,8 +112,12 @@ function requestHandler (environment, server, state, verifier) {
     await new Promise(resolve => server.stop(resolve));
     debug(`stopped http server listening on ${PORT}`);
 
-    if (params.state !== state) {
-      throw new Error('An error occurred during authentication');
+    debug(`state expected:${state} actual:${params.state}`);
+
+    if (!params.state) {
+      console.log(chalk.yellow('OAuth state is missing in the callback. Ignoring.'));
+    } else if (params.state !== state) {
+      throw new Error('An error occurred during authentication: the OAuth state does not match');
     }
 
     const defaults = config.get(`${environment}.defaults`);


### PR DESCRIPTION
Also added some additional debug statements to help troubleshoot
this sort of problem.

For some reason Cognito isn't passing back any state query
param on the redirect callback in prod (it does pass a state
back in dev) when using SAML SSO.
I'll be opening an AWS support case to figure out
what's going on, but for now this work around gets us past
the problem.