### PR TITLE
Use proper file name when uploading on windows

### DIFF
--- a/lib/cmds/files_cmds/upload.js
+++ b/lib/cmds/files_cmds/upload.js
@@ -93,7 +93,7 @@ exports.handler = async argv => {
     // eslint-disable-next-line security/detect-non-literal-fs-filename
     let stats = fs.statSync(file);
     const fileSize = stats['size'];
-    const fileName = file.startsWith('./') ? file.slice(2) : file;
+    const fileName = (file.startsWith('./') ? file.slice(2) : file).replace(/\\/g, '/');
 
     try {
       if (fileSize > MULTIPART_MIN_SIZE) {


### PR DESCRIPTION
Files are getting upload like `folder\\file.txt` so "folders" are not getting created in s3.  