### PR TITLE
Separate Cohort and Dataset Insights Query Commands

### DIFF
--- a/lib/cmds/insights_cmds/query-cohort.js
+++ b/lib/cmds/insights_cmds/query-cohort.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const { post } = require('../../api');
+const print = require('../../print');
+const read = require('../../read');
+
+exports.command = 'query-cohort <cohortId>';
+exports.desc = 'Submits a cohort query to the Lifeomic analytics API.  JSON query can be read from stdin.';
+exports.builder = yargs => {
+  yargs.positional('cohortId', {
+    describe: 'The ID of the cohort to search within.',
+    type: 'string'
+  }).options({
+    sql: {
+      describe: 'The SQL query to run',
+      type: 'string',
+      alias: 's'
+    }
+  });
+};
+
+exports.handler = async argv => {
+  const contract = {
+    cohort_id: argv.cohortId
+  };
+
+  if (argv.sql) {
+    contract.string_query = argv.sql;
+  } else {
+    contract.query = await read(argv);
+  }
+
+  const response = await post(argv, `/v1/analytics/dsl`, contract);
+  print(response.data, argv);
+};

--- a/lib/cmds/insights_cmds/query-dataset.js
+++ b/lib/cmds/insights_cmds/query-dataset.js
@@ -4,17 +4,13 @@ const { post } = require('../../api');
 const print = require('../../print');
 const read = require('../../read');
 
-exports.command = 'query <datasetId>';
-exports.desc = 'DEPRECATED. Use query-cohort or query-dataset commands. Submits query to the Lifeomic analytics API.  JSON query can be read from stdin.';
+exports.command = 'query-dataset <datasetId>';
+exports.desc = 'Submits a dataset query to the Lifeomic analytics API.  JSON query can be read from stdin.';
 exports.builder = yargs => {
   yargs.positional('datasetId', {
-    describe: 'The ID of the project to search within.',
+    describe: 'The ID of the dataset to search within.',
     type: 'string'
   }).options({
-    cohortId: {
-      describe: 'The ID of the cohort to search within.',
-      type: 'string'
-    },
     sql: {
       describe: 'The SQL query to run',
       type: 'string',
@@ -24,18 +20,9 @@ exports.builder = yargs => {
 };
 
 exports.handler = async argv => {
-  const { datasetId, cohortId } = argv;
-
-  let contract;
-  if (cohortId) {
-    contract = {
-      cohort_id: cohortId
-    };
-  } else {
-    contract = {
-      dataset_id: datasetId
-    };
-  }
+  const contract = {
+    dataset_id: argv.datasetId
+  };
 
   if (argv.sql) {
     contract.string_query = argv.sql;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/cli",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "CLI for interacting with the LifeOmic PHC API.",
   "main": "lo.js",
   "author": "LifeOmic <development@lifeomic.com>",

--- a/test/unit/commands/insights-test.js
+++ b/test/unit/commands/insights-test.js
@@ -10,7 +10,7 @@ const printSpy = sinon.spy();
 const readStub = sinon.stub();
 let callback;
 
-const program = proxyquire('../../../lib/cmds/insights_cmds/query', {
+const mocks = {
   '../../api': {
     post: postStub
   },
@@ -19,7 +19,11 @@ const program = proxyquire('../../../lib/cmds/insights_cmds/query', {
     callback();
   },
   '../../read': async () => readStub()
-});
+};
+
+const program = proxyquire('../../../lib/cmds/insights_cmds/query', mocks);
+const queryCohortCmd = proxyquire('../../../lib/cmds/insights_cmds/query-cohort', mocks);
+const queryDatasetCmd = proxyquire('../../../lib/cmds/insights_cmds/query-dataset', mocks);
 
 test.afterEach.always(t => {
   postStub.resetHistory();
@@ -80,4 +84,68 @@ test.serial.cb('The "insights-run-query" command allows cohort to be used', t =>
 
   yargs.command(program)
     .parse('query 1 --cohortId 2');
+});
+
+test.serial.cb('The "query-cohort" command should post a json query', t => {
+  const res = { data: { genes: ['A'], samples: ['X', 'Y', 'Z'] } };
+  postStub.onFirstCall().returns(res);
+  readStub.onFirstCall().returns('{}');
+
+  callback = () => {
+    t.is(postStub.callCount, 1);
+    t.is(postStub.getCall(0).args[1], '/v1/analytics/dsl');
+    t.is(printSpy.callCount, 1);
+    t.deepEqual(printSpy.getCall(0).args[0], res.data);
+    t.end();
+  };
+
+  yargs.command(queryCohortCmd)
+    .parse('query-cohort 1');
+});
+
+test.serial.cb('The "query-cohort" command should post a json query with sql option', t => {
+  const res = { data: { genes: ['A'], samples: ['X', 'Y', 'Z'] } };
+  postStub.onFirstCall().returns(res);
+  callback = () => {
+    t.is(postStub.callCount, 1);
+    t.is(postStub.getCall(0).args[1], '/v1/analytics/dsl');
+    t.is(printSpy.callCount, 1);
+    t.deepEqual(printSpy.getCall(0).args[0], res.data);
+    t.end();
+  };
+
+  yargs.command(queryCohortCmd)
+    .parse('query-cohort 1 --sql "SELECT filter FROM gene"');
+});
+
+test.serial.cb('The "query-dataset" command should post a json query', t => {
+  const res = { data: { genes: ['A'], samples: ['X', 'Y', 'Z'] } };
+  postStub.onFirstCall().returns(res);
+  readStub.onFirstCall().returns('{}');
+
+  callback = () => {
+    t.is(postStub.callCount, 1);
+    t.is(postStub.getCall(0).args[1], '/v1/analytics/dsl');
+    t.is(printSpy.callCount, 1);
+    t.deepEqual(printSpy.getCall(0).args[0], res.data);
+    t.end();
+  };
+
+  yargs.command(queryDatasetCmd)
+    .parse('query-dataset 1');
+});
+
+test.serial.cb('The "query-dataset" command should post a json query with sql option', t => {
+  const res = { data: { genes: ['A'], samples: ['X', 'Y', 'Z'] } };
+  postStub.onFirstCall().returns(res);
+  callback = () => {
+    t.is(postStub.callCount, 1);
+    t.is(postStub.getCall(0).args[1], '/v1/analytics/dsl');
+    t.is(printSpy.callCount, 1);
+    t.deepEqual(printSpy.getCall(0).args[0], res.data);
+    t.end();
+  };
+
+  yargs.command(queryDatasetCmd)
+    .parse('query-dataset 1 --sql "SELECT filter FROM gene"');
 });


### PR DESCRIPTION
Currently, the insights `query` command has a positional argument for dataset id and an optional argument for cohort id. When a cohort is queried, a dataset id is still required (although only an error is logged).

These changes separate the `query` command into `query-dataset` and `query-cohort` commands. The `query` command is still available, with a deprecation warning added to the description.