### PR TITLE
Don't colorize output when connected to a pipe.

### DIFF
--- a/lib/print.js
+++ b/lib/print.js
@@ -22,6 +22,6 @@ module.exports = function (data, options) {
   } else if (options.jsonLine) {
     console.log(JSON.stringify(data, null, 0));
   } else {
-    console.log(prettyoutput(data));
+    console.log(prettyoutput(data, {noColor: !process.stdout.isTTY}));
   }
 };

--- a/test/unit/print.test.js
+++ b/test/unit/print.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const test = require('ava');
+const sinon = require('sinon');
+
+const proxyquire = require('proxyquire');
+
+const prettyoutput = sinon.stub();
+
+const print = proxyquire('../../lib/print', {
+  'prettyoutput': prettyoutput
+});
+
+test.beforeEach(t => {
+  prettyoutput.reset();
+});
+
+test('non tty output (e.g. pipe) should suppress colorization so downstream text parsing is not broken', async t => {
+  process.stdout.isTTY = false;
+
+  const data = {foo: 'bar'};
+  print(data, {});
+  t.pass(sinon.assert.calledWithExactly(prettyoutput, data, {noColor: true}));
+});
+
+test('tty output (e.g. terminal) should colorize', async t => {
+  process.stdout.isTTY = true;
+
+  const data = {foo: 'bar'};
+  print(data, {});
+  t.pass(sinon.assert.calledWithExactly(prettyoutput, data, {noColor: false}));
+});


### PR DESCRIPTION
The color control characters mess up any downstream text parsing.