### PR TITLE
print out deeper yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.2.1]  - 2019-08-10
+
+### Fixed
+
+- `lo` yaml output will now go deeper rather than cutting off at 3 levels deep
+
 ## [8.2.0]  - 2019-07-24
 
 ### Added

--- a/lib/print.js
+++ b/lib/print.js
@@ -22,6 +22,6 @@ module.exports = function (data, options) {
   } else if (options.jsonLine) {
     console.log(JSON.stringify(data, null, 0));
   } else {
-    console.log(prettyoutput(data, {noColor: !process.stdout.isTTY}));
+    console.log(prettyoutput(data, {noColor: !process.stdout.isTTY, maxDepth: 100}));
   }
 };

--- a/test/unit/print.test.js
+++ b/test/unit/print.test.js
@@ -20,7 +20,7 @@ test('non tty output (e.g. pipe) should suppress colorization so downstream text
 
   const data = {foo: 'bar'};
   print(data, {});
-  t.pass(sinon.assert.calledWithExactly(prettyoutput, data, {noColor: true}));
+  t.pass(sinon.assert.calledWithExactly(prettyoutput, data, {maxDepth: 100, noColor: true}));
 });
 
 test('tty output (e.g. terminal) should colorize', async t => {
@@ -28,5 +28,5 @@ test('tty output (e.g. terminal) should colorize', async t => {
 
   const data = {foo: 'bar'};
   print(data, {});
-  t.pass(sinon.assert.calledWithExactly(prettyoutput, data, {noColor: false}));
+  t.pass(sinon.assert.calledWithExactly(prettyoutput, data, {maxDepth: 100, noColor: false}));
 });


### PR DESCRIPTION
Previously it was defaulting to 3 levels deep, which often
resulted in cut off objects