### PR TITLE
Adding in options to pull genomics sets by missing values

### DIFF
--- a/lib/cmds/genomics_cmds/list-copy-number-sets.js
+++ b/lib/cmds/genomics_cmds/list-copy-number-sets.js
@@ -2,6 +2,7 @@
 
 const { post, list } = require('../../ga4gh');
 const print = require('../../print');
+const genomicFilter = require('../../genomic-filter');
 
 exports.command = 'list-copy-number-sets <datasetId>';
 exports.desc = 'List copy number sets by dataset <datasetId>.';
@@ -35,6 +36,31 @@ exports.builder = yargs => {
     describe: 'The patient to filter results by',
     alias: 'p',
     type: 'string'
+  }).option('missing-patient', {
+    describe: 'Only return records missing patientIds',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('missing-sequence', {
+    describe: 'Only return records missing sequenceIds',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('missing-samples', {
+    describe: 'Only return records missing sample names',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('missing-fhir-sequence', {
+    describe: 'Only return records missing fhir sequences',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('only-ids', {
+    describe: 'Only returns the ids of the records, useful for generating data sources for scripts',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
   });
 };
 
@@ -57,11 +83,13 @@ exports.handler = async argv => {
 
   if (argv.limit) {
     const response = await list(argv, `/copynumbersets/search`, body, 'copyNumberSets');
+    response.data.copyNumberSets = await genomicFilter(response.data.copyNumberSets, argv);
     print(response, argv);
   } else {
     body.pageSize = argv.pageSize;
     body.pageToken = argv.nextPageToken;
     const response = await post(argv, `/copynumbersets/search`, body);
+    response.data.copyNumberSets = await genomicFilter(response.data.copyNumberSets, argv);
     print(response.data, argv);
   }
 };

--- a/lib/cmds/genomics_cmds/list-readgroup-sets.js
+++ b/lib/cmds/genomics_cmds/list-readgroup-sets.js
@@ -2,6 +2,7 @@
 
 const { post, list } = require('../../ga4gh');
 const print = require('../../print');
+const genomicFilter = require('../../genomic-filter');
 
 exports.command = 'list-readgroup-sets <datasetId>';
 exports.desc = 'List readgroup sets by dataset <datasetId>.';
@@ -22,6 +23,31 @@ exports.builder = yargs => {
     describe: 'Next page token',
     alias: 't',
     type: 'string'
+  }).option('missing-patient', {
+    describe: 'Only return records missing patientIds',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('missing-sequence', {
+    describe: 'Only return records missing sequenceIds',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('missing-samples', {
+    describe: 'Only return records missing sample names',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('missing-fhir-sequence', {
+    describe: 'Only return records missing fhir sequences',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('only-ids', {
+    describe: 'Only returns the ids of the records, useful for generating data sources for scripts',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
   });
 };
 
@@ -30,6 +56,7 @@ exports.handler = async argv => {
     const response = await list(argv, `/readgroupsets/search`, {
       datasetIds: [argv.datasetId]
     }, 'readGroupSets');
+    response.data.readGroupSets = await genomicFilter(response.data.readGroupSets, argv);
     print(response, argv);
   } else {
     const response = await post(argv, `/readgroupsets/search`, {
@@ -37,6 +64,7 @@ exports.handler = async argv => {
       pageSize: argv.pageSize,
       pageToken: argv.nextPageToken
     });
+    response.data.readGroupSets = await genomicFilter(response.data.readGroupSets, argv);
     print(response.data, argv);
   }
 };

--- a/lib/cmds/genomics_cmds/list-rna-quantification-sets.js
+++ b/lib/cmds/genomics_cmds/list-rna-quantification-sets.js
@@ -2,6 +2,7 @@
 
 const { post, list } = require('../../ga4gh');
 const print = require('../../print');
+const genomicFilter = require('../../genomic-filter');
 
 exports.command = 'list-rna-quantification-sets <datasetId>';
 exports.desc = 'List RNA quantification sets by dataset <datasetId>.';
@@ -35,6 +36,31 @@ exports.builder = yargs => {
     describe: 'The patient to filter results by',
     alias: 'p',
     type: 'string'
+  }).option('missing-patient', {
+    describe: 'Only return records missing patientIds',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('missing-sequence', {
+    describe: 'Only return records missing sequenceIds',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('missing-samples', {
+    describe: 'Only return records missing sample names',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('missing-fhir-sequence', {
+    describe: 'Only return records missing fhir sequences',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('only-ids', {
+    describe: 'Only returns the ids of the records, useful for generating data sources for scripts',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
   });
 };
 
@@ -57,11 +83,13 @@ exports.handler = async argv => {
 
   if (argv.limit) {
     const response = await list(argv, `/rnaquantificationsets/search`, body, 'rnaQuantificationSets');
+    response.data.rnaQuantificationSets = await genomicFilter(response.data.rnaQuantificationSets, argv);
     print(response, argv);
   } else {
     body.pageSize = argv.pageSize;
     body.pageToken = argv.nextPageToken;
     const response = await post(argv, `/rnaquantificationsets/search`, body);
+    response.data.rnaQuantificationSets = await genomicFilter(response.data.rnaQuantificationSets, argv);
     print(response.data, argv);
   }
 };

--- a/lib/cmds/genomics_cmds/list-structural-variant-sets.js
+++ b/lib/cmds/genomics_cmds/list-structural-variant-sets.js
@@ -2,6 +2,7 @@
 
 const { post, list } = require('../../ga4gh');
 const print = require('../../print');
+const genomicFilter = require('../../genomic-filter');
 
 exports.command = 'list-structural-variant-sets <datasetId>';
 exports.desc = 'List structural variant sets by dataset <datasetId>.';
@@ -35,6 +36,31 @@ exports.builder = yargs => {
     describe: 'The patient to filter results by',
     alias: 'p',
     type: 'string'
+  }).option('missing-patient', {
+    describe: 'Only return records missing patientIds',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('missing-sequence', {
+    describe: 'Only return records missing sequenceIds',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('missing-samples', {
+    describe: 'Only return records missing sample names',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('missing-fhir-sequence', {
+    describe: 'Only return records missing fhir sequences',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('only-ids', {
+    describe: 'Only returns the ids of the records, useful for generating data sources for scripts',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
   });
 };
 
@@ -57,11 +83,13 @@ exports.handler = async argv => {
 
   if (argv.limit) {
     const response = await list(argv, `/fusionsets/search`, body, 'fusionSets');
+    response.data.fusionSets = await genomicFilter(response.data.fusionSets, argv);
     print(response, argv);
   } else {
     body.pageSize = argv.pageSize;
     body.pageToken = argv.nextPageToken;
     const response = await post(argv, `/fusionsets/search`, body);
+    response.data.fusionSets = await genomicFilter(response.data.fusionSets, argv);
     print(response.data, argv);
   }
 };

--- a/lib/cmds/genomics_cmds/list-variant-sets.js
+++ b/lib/cmds/genomics_cmds/list-variant-sets.js
@@ -2,6 +2,7 @@
 
 const { post, list } = require('../../ga4gh');
 const print = require('../../print');
+const genomicFilter = require('../../genomic-filter');
 
 exports.command = 'list-variant-sets <datasetId>';
 exports.desc = 'List variant sets by dataset <datasetId>.';
@@ -35,6 +36,31 @@ exports.builder = yargs => {
     describe: 'The patient to filter results by',
     alias: 'p',
     type: 'string'
+  }).option('missing-patient', {
+    describe: 'Only return records missing patientIds',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('missing-sequence', {
+    describe: 'Only return records missing sequenceIds',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('missing-samples', {
+    describe: 'Only return records missing sample names',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('missing-fhir-sequence', {
+    describe: 'Only return records missing fhir sequences',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
+  }).option('only-ids', {
+    describe: 'Only returns the ids of the records, useful for generating data sources for scripts',
+    type: 'Boolean',
+    default: false,
+    demandOption: false
   });
 };
 
@@ -57,11 +83,13 @@ exports.handler = async argv => {
 
   if (argv.limit) {
     const response = await list(argv, `/variantsets/search`, body, 'variantSets');
+    response.data.variantSets = await genomicFilter(response.data.variantSets, argv);
     print(response, argv);
   } else {
     body.pageSize = argv.pageSize;
     body.pageToken = argv.nextPageToken;
     const response = await post(argv, `/variantsets/search`, body);
+    response.data.variantSets = await genomicFilter(response.data.variantSets, argv);
     print(response.data, argv);
   }
 };

--- a/lib/genomic-filter.js
+++ b/lib/genomic-filter.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { get, getAccount } = require('./fhir');
+
+module.exports = async function (sets, argv) {
+  if (sets === undefined || sets.length === 0) {
+    return sets;
+  }
+
+  const filteredSets = sets
+    .filter(d => (!argv.missingPatient || d.patientId === undefined) &&
+      (!argv.missingSequence || d.sequenceId === undefined) &&
+      (!argv.missingSamples || (d.status === 'ACTIVE' && (!d.samples ||
+        (d.samples.length === 0 || d.samples.filter(s => s.sampleId).length === 0)))));
+
+  const results = [];
+  for (let i = 0; i < filteredSets.length; i++) {
+    if (await includeSequenceInResults(argv, filteredSets[i].sequenceId)) {
+      results.push(filteredSets[i]);
+    }
+  }
+
+  return results
+    .map(d => argv.onlyIds ? d.id : d);
+};
+
+async function includeSequenceInResults (argv, id) {
+  if (argv.missingFhirSequence) {
+    if (id === undefined) {
+      return false;
+    }
+    try {
+      const account = getAccount(argv);
+      const url = `/${account}/dstu3/Sequence/${id}`;
+      await get(argv, url);
+      // we only return true if we get the 404 err
+      return false;
+    } catch (err) {
+      if (err.message === 'Request failed with status code 404') {
+        return true;
+      }
+
+      console.error(err);
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/test/unit/commands/ga4gh-rna-quantificationsets.test.js
+++ b/test/unit/commands/ga4gh-rna-quantificationsets.test.js
@@ -37,7 +37,7 @@ test.always.afterEach(t => {
 });
 
 test.serial.cb('The "ga4gh-rnaquantificationsets" command should list rna sets for an account', t => {
-  const res = { data: { rnaquantificationsets: [] } };
+  const res = { data: { rnaQuantificationSets: [] } };
   postStub.onFirstCall().returns(res);
   listStub.onFirstCall().returns(res);
   callback = () => {
@@ -52,7 +52,7 @@ test.serial.cb('The "ga4gh-rnaquantificationsets" command should list rna sets f
       status: 'INDEXING'
     });
     t.is(printSpy.callCount, 1);
-    t.true(printSpy.calledWith({ rnaquantificationsets: [] }));
+    t.true(printSpy.calledWith({ rnaQuantificationSets: [] }));
     t.end();
   };
 
@@ -69,7 +69,7 @@ test.serial.cb('The "ga4gh-rnaquantificationsets" command should list rna sets f
       status: 'INDEXING'
     });
     t.is(printSpy.callCount, 1);
-    t.true(printSpy.calledWith({ rnaquantificationsets: [] }));
+    t.true(printSpy.calledWith({ rnaQuantificationSets: [] }));
     t.end();
   };
 
@@ -78,7 +78,7 @@ test.serial.cb('The "ga4gh-rnaquantificationsets" command should list rna sets f
 });
 
 test.serial.cb('The "ga4gh-rnaquantificationsets" command should list rna sets for an account filtered by sequence', t => {
-  const res = { data: { rnaquantificationsets: [] } };
+  const res = { data: { rnaQuantificationSets: [] } };
   postStub.onFirstCall().returns(res);
   listStub.onFirstCall().returns(res);
   callback = () => {
@@ -110,7 +110,7 @@ test.serial.cb('The "ga4gh-rnaquantificationsets" command should list rna sets f
       sequenceId: 'sequenceId'
     });
     t.is(printSpy.callCount, 1);
-    t.true(printSpy.calledWith({ rnaquantificationsets: [] }));
+    t.true(printSpy.calledWith({ rnaQuantificationSets: [] }));
     t.end();
   };
 
@@ -119,7 +119,7 @@ test.serial.cb('The "ga4gh-rnaquantificationsets" command should list rna sets f
 });
 
 test.serial.cb('The "ga4gh-rnaquantificationsets" command should list rna sets for an account filtered by patient', t => {
-  const res = { data: { rnaquantificationsets: [] } };
+  const res = { data: { rnaQuantificationSets: [] } };
   postStub.onFirstCall().returns(res);
   listStub.onFirstCall().returns(res);
   callback = () => {
@@ -134,7 +134,7 @@ test.serial.cb('The "ga4gh-rnaquantificationsets" command should list rna sets f
       patientId: 'patientId'
     });
     t.is(printSpy.callCount, 1);
-    t.true(printSpy.calledWith({ rnaquantificationsets: [] }));
+    t.true(printSpy.calledWith({ rnaQuantificationSets: [] }));
     t.end();
   };
 
@@ -151,7 +151,7 @@ test.serial.cb('The "ga4gh-rnaquantificationsets" command should list rna sets f
       patientId: 'patientId'
     });
     t.is(printSpy.callCount, 1);
-    t.true(printSpy.calledWith({ rnaquantificationsets: [] }));
+    t.true(printSpy.calledWith({ rnaQuantificationSets: [] }));
     t.end();
   };
 

--- a/test/unit/genomic-filter.test.js
+++ b/test/unit/genomic-filter.test.js
@@ -13,7 +13,8 @@ const genomicFilter = proxyquire(`../../lib/genomic-filter`, {
       return {};
     },
 
-    getEnvironment () { return 'test'; }
+    getEnvironment () { return 'test'; },
+    getAccount: () => 'lifeomic'
   }
 });
 

--- a/test/unit/genomic-filter.test.js
+++ b/test/unit/genomic-filter.test.js
@@ -12,6 +12,10 @@ const genomicFilter = proxyquire(`../../lib/genomic-filter`, {
 
       return {};
     }
+  },
+  './interceptor/tokenProvider': requestConfig => requestConfig,
+  './config': {
+    getEnvironment () { return 'test'; }
   }
 });
 

--- a/test/unit/genomic-filter.test.js
+++ b/test/unit/genomic-filter.test.js
@@ -11,10 +11,8 @@ const genomicFilter = proxyquire(`../../lib/genomic-filter`, {
       }
 
       return {};
-    }
-  },
-  './interceptor/tokenProvider': requestConfig => requestConfig,
-  './config': {
+    },
+
     getEnvironment () { return 'test'; }
   }
 });

--- a/test/unit/genomic-filter.test.js
+++ b/test/unit/genomic-filter.test.js
@@ -1,0 +1,404 @@
+'use strict';
+
+const test = require('ava');
+const proxyquire = require('proxyquire');
+
+const genomicFilter = proxyquire(`../../lib/genomic-filter`, {
+  './fhir': {
+    get (options, path, config) {
+      if (path === '/lifeomic/dstu3/Sequence/sequence2') {
+        throw new Error('Request failed with status code 404');
+      }
+
+      return {};
+    }
+  }
+});
+
+test('genomic-filter should filter patientId arguments if true', async t => {
+  const argv = {
+    missingPatient: true
+  };
+
+  const sets = [{
+    id: 'id1',
+    patientId: 'patient1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id2',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id3',
+    patientId: 'patient1',
+    sequenceName: 'sequenceName'
+  }];
+
+  const results = await genomicFilter(sets, argv);
+  t.deepEqual(results, [{
+    id: 'id2',
+    sequenceName: 'sequenceName'
+  }]);
+});
+
+test('genomic-filter should not filter patientId arguments if false', async t => {
+  const argv = {
+    missingPatient: false
+  };
+
+  const sets = [{
+    id: 'id1',
+    patientId: 'patient1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id2',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id3',
+    patientId: 'patient1',
+    sequenceName: 'sequenceName'
+  }];
+
+  const results = await genomicFilter(sets, argv);
+  t.deepEqual(results, [{
+    id: 'id1',
+    patientId: 'patient1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id2',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id3',
+    patientId: 'patient1',
+    sequenceName: 'sequenceName'
+  }]);
+});
+
+test('genomic-filter should filter sequenceId arguments if true', async t => {
+  const argv = {
+    missingSequence: true
+  };
+
+  const sets = [{
+    id: 'id1',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id2',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id3',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }];
+
+  const results = await genomicFilter(sets, argv);
+  t.deepEqual(results, [{
+    id: 'id2',
+    sequenceName: 'sequenceName'
+  }]);
+});
+
+test('genomic-filter should not filter sequenceId arguments if false', async t => {
+  const argv = {
+    missingSequence: false
+  };
+
+  const sets = [{
+    id: 'id1',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id2',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id3',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }];
+
+  const results = await genomicFilter(sets, argv);
+  t.deepEqual(results, [{
+    id: 'id1',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id2',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id3',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }]);
+});
+
+test('genomic-filter should filter patientId/sequenceId arguments if both are true', async t => {
+  const argv = {
+    missingPatient: true,
+    missingSequence: true
+  };
+
+  const sets = [{
+    id: 'id1',
+    patientId: 'patient1',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id2',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id3',
+    patientId: 'patient1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id4',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }];
+
+  const results = await genomicFilter(sets, argv);
+  t.deepEqual(results, [{
+    id: 'id2',
+    sequenceName: 'sequenceName'
+  }]);
+});
+
+test('genomic-filter should not filter patientId/sequenceId arguments if both are false', async t => {
+  const argv = {
+    missingPatient: false,
+    missingSequence: false
+  };
+
+  const sets = [{
+    id: 'id1',
+    patientId: 'patient1',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id2',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id3',
+    patientId: 'patient1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id4',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }];
+
+  const results = await genomicFilter(sets, argv);
+  t.deepEqual(results, [{
+    id: 'id1',
+    patientId: 'patient1',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id2',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id3',
+    patientId: 'patient1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id4',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }]);
+});
+
+test('genomic-filter should not filter patientId/sequenceId arguments dont exit', async t => {
+  const argv = { };
+
+  const sets = [{
+    id: 'id1',
+    patientId: 'patient1',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id2',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id3',
+    patientId: 'patient1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id4',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }];
+
+  const results = await genomicFilter(sets, argv);
+  t.deepEqual(results, [{
+    id: 'id1',
+    patientId: 'patient1',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id2',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id3',
+    patientId: 'patient1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id4',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }]);
+});
+
+test('genomic-filter should filter print only ids if only-ids argument is used', async t => {
+  const argv = {
+    onlyIds: true
+  };
+
+  const sets = [{
+    id: 'id1',
+    patientId: 'patient1',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id2',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id3',
+    patientId: 'patient1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id4',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }];
+
+  const results = await genomicFilter(sets, argv);
+  t.deepEqual(results, ['id1', 'id2', 'id3', 'id4']);
+});
+
+test('genomic-filter should filter print only ids if only-ids argument is used when including filters', async t => {
+  const argv = {
+    onlyIds: true,
+    missingSequence: true
+  };
+
+  const sets = [{
+    id: 'id1',
+    patientId: 'patient1',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id2',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id3',
+    patientId: 'patient1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id4',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }];
+
+  const results = await genomicFilter(sets, argv);
+  t.deepEqual(results, ['id2', 'id3']);
+});
+
+test('genomic-filter should filter missing samples for ACTIVE records', async t => {
+  const argv = {
+    missingSamples: true
+  };
+
+  const sets = [{
+    id: 'id1',
+    patientId: 'patient1',
+    status: 'ACTIVE',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id2',
+    sequenceName: 'sequenceName',
+    status: 'ACTIVE',
+    samples: [{
+      sampleId: 'SA-QWERTY',
+      patientId: 'c89e14b7-af05-4c38-865c-a607c295adb2'
+    }]
+  }, {
+    id: 'id3',
+    patientId: 'patient1',
+    sequenceName: 'sequenceName',
+    status: 'INDEXING',
+    samples: [{
+      sampleId: 'SA-QWERTY',
+      patientId: 'c89e14b7-af05-4c38-865c-a607c295adb2'
+    }]
+  }, {
+    id: 'id4',
+    status: 'INDEXING',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }];
+
+  const results = await genomicFilter(sets, argv);
+  t.deepEqual(results, [{
+    id: 'id1',
+    patientId: 'patient1',
+    status: 'ACTIVE',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }]);
+});
+
+test('genomic-filter should filter missing FHIR sequences', async t => {
+  const argv = {
+    missingFhirSequence: true
+  };
+
+  const sets = [{
+    id: 'id1',
+    patientId: 'patient1',
+    status: 'ACTIVE',
+    sequenceId: 'sequence1',
+    sequenceName: 'sequenceName'
+  }, {
+    id: 'id2',
+    sequenceName: 'sequenceName',
+    status: 'ACTIVE',
+    samples: [{
+      sampleId: 'SA-QWERTY',
+      patientId: 'c89e14b7-af05-4c38-865c-a607c295adb2'
+    }]
+  }, {
+    id: 'id3',
+    patientId: 'patient1',
+    sequenceName: 'sequenceName',
+    status: 'INDEXING',
+    samples: [{
+      sampleId: 'SA-QWERTY',
+      patientId: 'c89e14b7-af05-4c38-865c-a607c295adb2'
+    }]
+  }, {
+    id: 'id4',
+    patientId: 'patient1',
+    sequenceName: 'sequenceName',
+    sequenceId: 'sequence2',
+    status: 'ACTIVE',
+    samples: [{
+      sampleId: 'SA-QWERTY',
+      patientId: 'c89e14b7-af05-4c38-865c-a607c295adb2'
+    }]
+  }];
+
+  const results = await genomicFilter(sets, argv);
+  console.log(`${JSON.stringify(results)}`);
+
+  t.deepEqual(results, [{
+    id: 'id4',
+    patientId: 'patient1',
+    sequenceName: 'sequenceName',
+    sequenceId: 'sequence2',
+    status: 'ACTIVE',
+    samples: [{
+      sampleId: 'SA-QWERTY',
+      patientId: 'c89e14b7-af05-4c38-865c-a607c295adb2'
+    }]
+  }]);
+});


### PR DESCRIPTION
Added options to the genomics commands to filter by missing patientId, sequenceId, and no sampleIds in the samples array.  Also added a filter that will bounce the sequenceId against the FHIR endpoint to see if it exists there.  Lastly, an final option was added to map the output to just an array of ids, this is to facilitate generating output that may be easier to use as input to scripts to cleanup based up the list results.