### PR TITLE
Added --strip-path and --remote-path to files upload command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ interactive terminal or in a scripted environment.
 
 # Project Status
 
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Build Status](https://travis-ci.org/lifeomic/cli.svg?branch=master)](https://travis-ci.org/lifeomic/cli)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/lifeomic/cli)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
+![Travis (.org) branch](https://img.shields.io/travis/lifeomic/cli/master.svg?style=for-the-badge)
+![Downloads](https://img.shields.io/npm/dw/@lifeomic/cli?style=for-the-badge)
+![Version](https://img.shields.io/npm/v/@lifeomic/cli?style=for-the-badge)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=for-the-badge)](https://github.com/lifeomic/cli)
 
 **[Back to top](#table-of-contents)**
 

--- a/lib/cmds/files_cmds/upload.js
+++ b/lib/cmds/files_cmds/upload.js
@@ -85,6 +85,8 @@ exports.handler = async argv => {
 
   let files = [];
 
+  let fileIsDir = false;
+
   // eslint-disable-next-line security/detect-non-literal-fs-filename
   if (fs.lstatSync(argv.file).isDirectory()) {
     if (argv.recursive) {
@@ -97,6 +99,7 @@ exports.handler = async argv => {
         .filter(f => fs.lstatSync(path.join(argv.file, f)).isFile())
         .map(f => path.join(argv.file, f));
     }
+    fileIsDir=true;
   } else {
     files = [argv.file];
   }
@@ -106,7 +109,7 @@ exports.handler = async argv => {
     let stats = fs.statSync(file);
     const fileSize = stats['size'];
     const fileName = (file.startsWith('./') ? file.slice(2) : file).replace(/\\/g, '/');
-    const fileOnlyName = argv.stripPath ? fileName.substring(argv.file.length + 1) : fileName;
+    const fileOnlyName = getFileOnlyName(argv.stripPath, argv.file, fileIsDir, fileName);
     const remoteFileName = argv.remotePath && argv.remotePath.length > 0 ? argv.remotePath + '/' + fileOnlyName : fileOnlyName;
 
     try {
@@ -120,7 +123,7 @@ exports.handler = async argv => {
 
         await multipartUpload(argv, response.data.uploadId, file, fileSize);
         console.log(
-          chalk.green(`Upload complete: ${fileName}, ID: ${response.data.id}`)
+          chalk.green(`Upload complete: ${fileName} to ${remoteFileName}, ID: ${response.data.id}`)
         );
       } else {
         const verifyStream = await getFileVerificationStream(file, fileSize);
@@ -204,6 +207,24 @@ exports.handler = async argv => {
 
       // eslint-disable-next-line security/detect-non-literal-fs-filename
       fs.unlinkSync(file);
+    }
+  }
+
+  function getFileOnlyName(stripPath, baseFile, baseFileIsDir, fileName) {
+  	 if ( ! stripPath ) {
+		return fileName;
+    }
+
+    const baseFileName = baseFile.replace(/\\/g, '/');
+    var lastSepPath = baseFileName.lastIndexOf('/');
+    if ( baseFileIsDir ) {
+       lastSepPath = baseFileName.length;
+    }
+
+    if ( lastSepPath > 0 ) {
+       return fileName.substring(lastSepPath + 1);
+    } else {
+       return fileName;
     }
   }
 };

--- a/lib/cmds/files_cmds/upload.js
+++ b/lib/cmds/files_cmds/upload.js
@@ -241,9 +241,9 @@ exports.handler = async argv => {
     return (file.startsWith('./') ? file.slice(2) : file).replace(/\\/g, '/');
   }
   function getRemoteFileName (remotePath, fileOnlyName) {
-    const pathDelim = remotePath[remotePath.length-1] === '/' ? '' : '/';
+    const pathDelim = remotePath[remotePath.length - 1] === '/' ? '' : '/';
 
-    const remoteFileName = argv.remotePath && argv.remotePath.length > 0 ? argv.remotePath + '/' + fileOnlyName : fileOnlyName;
+    const remoteFileName = argv.remotePath && argv.remotePath.length > 0 ? argv.remotePath + pathDelim + fileOnlyName : fileOnlyName;
     console.log('remoteFileName = ' + remoteFileName);
     return remoteFileName;
   }

--- a/lib/cmds/files_cmds/upload.js
+++ b/lib/cmds/files_cmds/upload.js
@@ -113,9 +113,6 @@ exports.handler = async argv => {
     const fileOnlyName = getFileOnlyName(pathToStrip, fileName);
     const remoteFileName = getRemoteFileName(argv.remotePath, fileOnlyName);
 
-    console.log("fileOnlyName: " + fileOnlyName);
-    console.log("remoteFileName: " + remoteFileName);
-
     try {
       if (fileSize > MULTIPART_MIN_SIZE) {
         const response = await post(argv, UPLOADS_URL, {
@@ -226,8 +223,7 @@ exports.handler = async argv => {
       lastSepPath = baseFileName.length;
     }
 
-    let pathToStrip = filePath.substring(0, lastSepPath);
-    console.log("pathToStrip = " + pathToStrip);
+    const pathToStrip = filePath.substring(0, lastSepPath);
     return pathToStrip;
   }
 

--- a/lib/cmds/files_cmds/upload.js
+++ b/lib/cmds/files_cmds/upload.js
@@ -244,9 +244,9 @@ exports.handler = async argv => {
     if (!remotePath) {
       return fileOnlyName;
     }
-    const pathDelim = remotePath[remotePath.length - 1] === '/' ? '' : '/';
+    const pathDelim = remotePath[remotePath.length - 1] === '/' || fileOnlyName[0] === '/' ? '' : '/';
 
-    const remoteFileName = argv.remotePath && argv.remotePath.length > 0 ? argv.remotePath + pathDelim + fileOnlyName : fileOnlyName;
+    const remoteFileName = remotePath && remotePath.length > 0 ? remotePath + pathDelim + fileOnlyName : fileOnlyName;
     console.log('remoteFileName = ' + remoteFileName);
     return remoteFileName;
   }

--- a/lib/cmds/files_cmds/upload.js
+++ b/lib/cmds/files_cmds/upload.js
@@ -241,9 +241,8 @@ exports.handler = async argv => {
     return (file.startsWith('./') ? file.slice(2) : file).replace(/\\/g, '/');
   }
   function getRemoteFileName (remotePath, fileOnlyName) {
-    if (fileOnlyName[0] === '/') {
-      fileOnlyName = fileOnlyName.substring(1);
-    }
+    const pathDelim = remotePath[remotePath.length-1] === '/' ? '' : '/';
+
     const remoteFileName = argv.remotePath && argv.remotePath.length > 0 ? argv.remotePath + '/' + fileOnlyName : fileOnlyName;
     console.log('remoteFileName = ' + remoteFileName);
     return remoteFileName;

--- a/lib/cmds/files_cmds/upload.js
+++ b/lib/cmds/files_cmds/upload.js
@@ -67,6 +67,13 @@ exports.builder = yargs => {
       alias: 'i',
       type: 'boolean',
       default: false
+    }).option('remote-path', {
+      describe: 'Path to store this file on the PHC files for this dataset.',
+      type: 'string'
+    }).option('strip-path', {
+      describe: 'Strip local path from remote file path. This allows you to reference local a local path but removes it in the upload path.',
+      type: 'boolean',
+      default: false
     });
 };
 
@@ -99,12 +106,14 @@ exports.handler = async argv => {
     let stats = fs.statSync(file);
     const fileSize = stats['size'];
     const fileName = (file.startsWith('./') ? file.slice(2) : file).replace(/\\/g, '/');
+    const fileOnlyName = argv.stripPath ? fileName.substring(argv.file.length+1) : fileName;
+    const remoteFileName = argv.remotePath && argv.remotePath.length > 0 ? argv.remotePath + "/" + fileOnlyName : fileOnlyName;
 
     try {
       if (fileSize > MULTIPART_MIN_SIZE) {
         const response = await post(argv, UPLOADS_URL, {
           id: argv.id,
-          name: fileName,
+          name: remoteFileName,
           datasetId: argv.datasetId,
           overwrite: argv.overwrite || argv.force
         });
@@ -117,7 +126,7 @@ exports.handler = async argv => {
         const verifyStream = await getFileVerificationStream(file, fileSize);
         const body = {
           id: argv.id,
-          name: fileName,
+          name: remoteFileName,
           datasetId: argv.datasetId,
           overwrite: argv.overwrite || argv.force
         };

--- a/lib/cmds/files_cmds/upload.js
+++ b/lib/cmds/files_cmds/upload.js
@@ -113,6 +113,9 @@ exports.handler = async argv => {
     const fileOnlyName = getFileOnlyName(pathToStrip, fileName);
     const remoteFileName = getRemoteFileName(argv.remotePath, fileOnlyName);
 
+    console.log("fileOnlyName: " + fileOnlyName);
+    console.log("remoteFileName: " + remoteFileName);
+
     try {
       if (fileSize > MULTIPART_MIN_SIZE) {
         const response = await post(argv, UPLOADS_URL, {
@@ -143,7 +146,7 @@ exports.handler = async argv => {
 
         await upload(response.data.uploadUrl, fileSize, verifyStream.data, verifyStream.contentMD5);
         console.log(
-          chalk.green(`Upload complete: ${fileName}, ID: ${response.data.id}`)
+          chalk.green(`Upload complete: ${fileName} to ${remoteFileName}, ID: ${response.data.id}`)
         );
       }
     } catch (error) {
@@ -216,19 +219,21 @@ exports.handler = async argv => {
       return '';
     }
 
-    const baseFileName = filePath.replace(/\\/g, '/');
+    const baseFileName = normalizeFileName(filePath);
     let lastSepPath = baseFileName.lastIndexOf('/');
 
     if (isDir) {
       lastSepPath = baseFileName.length;
     }
 
-    return filePath.substring(0, lastSepPath);
+    let pathToStrip = filePath.substring(0, lastSepPath);
+    console.log("pathToStrip = " + pathToStrip);
+    return pathToStrip;
   }
 
   function getFileOnlyName (pathToStrip, fileName) {
     if (pathToStrip.length > 0) {
-      return fileName.substring(pathToStrip + 1);
+      return fileName.substring(pathToStrip.length);
     } else {
       return fileName;
     }

--- a/lib/cmds/files_cmds/upload.js
+++ b/lib/cmds/files_cmds/upload.js
@@ -106,8 +106,8 @@ exports.handler = async argv => {
     let stats = fs.statSync(file);
     const fileSize = stats['size'];
     const fileName = (file.startsWith('./') ? file.slice(2) : file).replace(/\\/g, '/');
-    const fileOnlyName = argv.stripPath ? fileName.substring(argv.file.length+1) : fileName;
-    const remoteFileName = argv.remotePath && argv.remotePath.length > 0 ? argv.remotePath + "/" + fileOnlyName : fileOnlyName;
+    const fileOnlyName = argv.stripPath ? fileName.substring(argv.file.length + 1) : fileName;
+    const remoteFileName = argv.remotePath && argv.remotePath.length > 0 ? argv.remotePath + '/' + fileOnlyName : fileOnlyName;
 
     try {
       if (fileSize > MULTIPART_MIN_SIZE) {

--- a/lib/cmds/files_cmds/upload.js
+++ b/lib/cmds/files_cmds/upload.js
@@ -20,6 +20,7 @@ const mkdirp = require('mkdirp');
 const FILES_URL = '/v1/files';
 const UPLOADS_URL = '/v1/uploads';
 const VERIFICATION_RETRIES = 5;
+const debug = require('debug')('files-upload');
 
 exports.command = 'upload <file> <datasetId>';
 exports.desc = 'Upload a local file or directory of files to a project.';
@@ -71,7 +72,7 @@ exports.builder = yargs => {
       describe: 'Path to store this file on the PHC files for this dataset.',
       type: 'string'
     }).option('strip-path', {
-      describe: 'Strip local path from remote file path. This allows you to reference local a local path but removes it in the upload path.',
+      describe: 'Strip local path from remote file path. This allows you to reference a local path but removes it in the upload path.',
       type: 'boolean',
       default: false
     });
@@ -149,7 +150,7 @@ exports.handler = async argv => {
     } catch (error) {
       if (_get(error, 'response.data.error', '').indexOf('already exists') > -1) {
         console.log(
-          chalk.yellow(`Ignoring already uploaded file: ${fileName}`)
+          chalk.yellow(`Ignoring already uploaded file: ${fileName} at ${remoteFileName}`)
         );
       } else {
         if (argv.ignore) {
@@ -225,7 +226,8 @@ exports.handler = async argv => {
 
     const pathToStrip = filePath.substring(0, lastSepPath + 1);
 
-    console.log('filePath=' + filePath + '\npathToStrip = ' + pathToStrip);
+    debug('filePath=' + filePath + '\npathToStrip = ' + pathToStrip);
+
     return pathToStrip;
   }
 
@@ -240,14 +242,16 @@ exports.handler = async argv => {
   function normalizeFileName (file) {
     return (file.startsWith('./') ? file.slice(2) : file).replace(/\\/g, '/');
   }
+
   function getRemoteFileName (remotePath, fileOnlyName) {
     if (!remotePath) {
       return fileOnlyName;
     }
     const pathDelim = remotePath[remotePath.length - 1] === '/' || fileOnlyName[0] === '/' ? '' : '/';
-
     const remoteFileName = remotePath && remotePath.length > 0 ? remotePath + pathDelim + fileOnlyName : fileOnlyName;
-    console.log('remoteFileName = ' + remoteFileName);
+
+    debug('remoteFileName = ' + remoteFileName);
+
     return remoteFileName;
   }
 };

--- a/lib/cmds/files_cmds/upload.js
+++ b/lib/cmds/files_cmds/upload.js
@@ -241,6 +241,9 @@ exports.handler = async argv => {
     return (file.startsWith('./') ? file.slice(2) : file).replace(/\\/g, '/');
   }
   function getRemoteFileName (remotePath, fileOnlyName) {
+    if (!remotePath) {
+      return fileOnlyName;
+    }
     const pathDelim = remotePath[remotePath.length - 1] === '/' ? '' : '/';
 
     const remoteFileName = argv.remotePath && argv.remotePath.length > 0 ? argv.remotePath + pathDelim + fileOnlyName : fileOnlyName;

--- a/lib/cmds/files_cmds/upload.js
+++ b/lib/cmds/files_cmds/upload.js
@@ -85,7 +85,7 @@ exports.handler = async argv => {
 
   let files = [];
 
-  let fileIsDir = false;
+  let pathToStrip = '';
 
   // eslint-disable-next-line security/detect-non-literal-fs-filename
   if (fs.lstatSync(argv.file).isDirectory()) {
@@ -99,18 +99,19 @@ exports.handler = async argv => {
         .filter(f => fs.lstatSync(path.join(argv.file, f)).isFile())
         .map(f => path.join(argv.file, f));
     }
-    fileIsDir=true;
+    pathToStrip = getPathToStrip(argv.stripPath, argv.file, true);
   } else {
     files = [argv.file];
+    pathToStrip = getPathToStrip(argv.stripPath, argv.file, false);
   }
 
   for (const file of files) {
     // eslint-disable-next-line security/detect-non-literal-fs-filename
     let stats = fs.statSync(file);
     const fileSize = stats['size'];
-    const fileName = (file.startsWith('./') ? file.slice(2) : file).replace(/\\/g, '/');
-    const fileOnlyName = getFileOnlyName(argv.stripPath, argv.file, fileIsDir, fileName);
-    const remoteFileName = argv.remotePath && argv.remotePath.length > 0 ? argv.remotePath + '/' + fileOnlyName : fileOnlyName;
+    const fileName = normalizeFileName(file);
+    const fileOnlyName = getFileOnlyName(pathToStrip, fileName);
+    const remoteFileName = getRemoteFileName(argv.remotePath, fileOnlyName);
 
     try {
       if (fileSize > MULTIPART_MIN_SIZE) {
@@ -210,21 +211,33 @@ exports.handler = async argv => {
     }
   }
 
-  function getFileOnlyName(stripPath, baseFile, baseFileIsDir, fileName) {
-  	 if ( ! stripPath ) {
-		return fileName;
+  function getPathToStrip (stripPath, filePath, isDir) {
+    if (!stripPath) {
+      return '';
     }
 
-    const baseFileName = baseFile.replace(/\\/g, '/');
-    var lastSepPath = baseFileName.lastIndexOf('/');
-    if ( baseFileIsDir ) {
-       lastSepPath = baseFileName.length;
+    const baseFileName = filePath.replace(/\\/g, '/');
+    let lastSepPath = baseFileName.lastIndexOf('/');
+
+    if (isDir) {
+      lastSepPath = baseFileName.length;
     }
 
-    if ( lastSepPath > 0 ) {
-       return fileName.substring(lastSepPath + 1);
+    return filePath.substring(0, lastSepPath);
+  }
+
+  function getFileOnlyName (pathToStrip, fileName) {
+    if (pathToStrip.length > 0) {
+      return fileName.substring(pathToStrip + 1);
     } else {
-       return fileName;
+      return fileName;
     }
+  }
+
+  function normalizeFileName (file) {
+    return (file.startsWith('./') ? file.slice(2) : file).replace(/\\/g, '/');
+  }
+  function getRemoteFileName (remotePath, fileOnlyName) {
+    return argv.remotePath && argv.remotePath.length > 0 ? argv.remotePath + '/' + fileOnlyName : fileOnlyName;
   }
 };

--- a/lib/cmds/files_cmds/upload.js
+++ b/lib/cmds/files_cmds/upload.js
@@ -223,7 +223,9 @@ exports.handler = async argv => {
       lastSepPath = baseFileName.length;
     }
 
-    const pathToStrip = filePath.substring(0, lastSepPath);
+    const pathToStrip = filePath.substring(0, lastSepPath + 1);
+
+    console.log('filePath=' + filePath + '\npathToStrip = ' + pathToStrip);
     return pathToStrip;
   }
 
@@ -239,6 +241,11 @@ exports.handler = async argv => {
     return (file.startsWith('./') ? file.slice(2) : file).replace(/\\/g, '/');
   }
   function getRemoteFileName (remotePath, fileOnlyName) {
-    return argv.remotePath && argv.remotePath.length > 0 ? argv.remotePath + '/' + fileOnlyName : fileOnlyName;
+    if ( fileOnlyName[0] == '/' ) {
+       fileOnlyName = fileOnlyName.substring(1);
+    }
+    const remoteFileName = argv.remotePath && argv.remotePath.length > 0 ? argv.remotePath + '/' + fileOnlyName : fileOnlyName;
+    console.log('remoteFileName = ' + remoteFileName);
+    return remoteFileName;
   }
 };

--- a/lib/cmds/files_cmds/upload.js
+++ b/lib/cmds/files_cmds/upload.js
@@ -241,8 +241,8 @@ exports.handler = async argv => {
     return (file.startsWith('./') ? file.slice(2) : file).replace(/\\/g, '/');
   }
   function getRemoteFileName (remotePath, fileOnlyName) {
-    if ( fileOnlyName[0] == '/' ) {
-       fileOnlyName = fileOnlyName.substring(1);
+    if (fileOnlyName[0] === '/') {
+      fileOnlyName = fileOnlyName.substring(1);
     }
     const remoteFileName = argv.remotePath && argv.remotePath.length > 0 ? argv.remotePath + '/' + fileOnlyName : fileOnlyName;
     console.log('remoteFileName = ' + remoteFileName);

--- a/test/unit/commands/file.test.js
+++ b/test/unit/commands/file.test.js
@@ -582,6 +582,117 @@ test.serial.cb('The "files-upload" command should upload a file with client supp
     .parse(`upload ${__dirname}/data/file1.txt dataset --id 1234`);
 });
 
+test.serial.cb('The "files-upload" command should upload a directory of files to a remote path', t => {
+  const res = { data: { uploadUrl: 'https://host/upload' } };
+  postStub.onFirstCall().returns(res);
+  postStub.onSecondCall().returns(res);
+
+  callback = () => {
+    if (postStub.callCount !== 2) {
+      return;
+    }
+    t.is(postStub.callCount, 2);
+    t.deepEqual(postStub.getCall(0).args[2], {
+      id: undefined,
+      name: `${__dirname}/data/file1.txt`,
+      datasetId: 'dataset',
+      overwrite: false,
+      contentMD5: 'contentMD5'
+    });
+    t.deepEqual(postStub.getCall(1).args[2], {
+      id: undefined,
+      name: `/foobar1/${__dirname}/data/file2.txt`,
+      datasetId: 'dataset',
+      overwrite: false,
+      contentMD5: 'contentMD5'
+    });
+
+    t.true(uploadSpy.calledWith('https://host/upload', 7));
+    t.true(getFileVerificationStreamStub.calledWith(`${__dirname}/data/file1.txt`, 7));
+    t.end();
+  };
+
+  t.context.deleteFileStub = t.context.sandbox.stub(fs, 'unlinkSync').callsFake(callback);
+  t.context.copyFileStub = t.context.sandbox.stub(fs, 'copyFileSync').callsFake(callback);
+
+  yargs.command(upload)
+    .parse(`upload ${__dirname}/data dataset --remote-path /foobar1`);
+});
+
+test.serial.cb('The "files-upload" command should upload a directory of files to a remote path stripping local path', t => {
+  const res = { data: { uploadUrl: 'https://host/upload' } };
+  postStub.onFirstCall().returns(res);
+  postStub.onSecondCall().returns(res);
+
+  callback = () => {
+    if (postStub.callCount !== 2) {
+      return;
+    }
+    t.is(postStub.callCount, 2);
+    t.deepEqual(postStub.getCall(0).args[2], {
+      id: undefined,
+      name: `/foobar1/file1.txt`,
+      datasetId: 'dataset',
+      overwrite: false,
+      contentMD5: 'contentMD5'
+    });
+    t.deepEqual(postStub.getCall(1).args[2], {
+      id: undefined,
+      name: `/foobar1/file2.txt`,
+      datasetId: 'dataset',
+      overwrite: false,
+      contentMD5: 'contentMD5'
+    });
+
+    t.true(uploadSpy.calledWith('https://host/upload', 7));
+    t.true(getFileVerificationStreamStub.calledWith(`${__dirname}/data/file1.txt`, 7));
+    t.end();
+  };
+
+  t.context.deleteFileStub = t.context.sandbox.stub(fs, 'unlinkSync').callsFake(callback);
+  t.context.copyFileStub = t.context.sandbox.stub(fs, 'copyFileSync').callsFake(callback);
+
+  yargs.command(upload)
+    .parse(`upload ${__dirname}/data dataset --strip-path --remote-path /foobar1`);
+});
+
+test.serial.cb('The "files-upload" command should upload a directory of files stripping local path', t => {
+  const res = { data: { uploadUrl: 'https://host/upload' } };
+  postStub.onFirstCall().returns(res);
+  postStub.onSecondCall().returns(res);
+
+  callback = () => {
+    if (postStub.callCount !== 2) {
+      return;
+    }
+    t.is(postStub.callCount, 2);
+    t.deepEqual(postStub.getCall(0).args[2], {
+      id: undefined,
+      name: `file1.txt`,
+      datasetId: 'dataset',
+      overwrite: false,
+      contentMD5: 'contentMD5'
+    });
+    t.deepEqual(postStub.getCall(1).args[2], {
+      id: undefined,
+      name: `file2.txt`,
+      datasetId: 'dataset',
+      overwrite: false,
+      contentMD5: 'contentMD5'
+    });
+
+    t.true(uploadSpy.calledWith('https://host/upload', 7));
+    t.true(getFileVerificationStreamStub.calledWith(`${__dirname}/data/file1.txt`, 7));
+    t.end();
+  };
+
+  t.context.deleteFileStub = t.context.sandbox.stub(fs, 'unlinkSync').callsFake(callback);
+  t.context.copyFileStub = t.context.sandbox.stub(fs, 'copyFileSync').callsFake(callback);
+
+  yargs.command(upload)
+    .parse(`upload ${__dirname}/data dataset --strip-path `);
+});
+
 test.serial.cb('The "files-upload" command should delete files after (verified) upload', t => {
   const res = { data: { uploadUrl: 'https://host/upload' } };
   postStub.onFirstCall().returns(res);

--- a/test/unit/commands/file.test.js
+++ b/test/unit/commands/file.test.js
@@ -594,7 +594,7 @@ test.serial.cb('The "files-upload" command should upload a directory of files to
     t.is(postStub.callCount, 2);
     t.deepEqual(postStub.getCall(0).args[2], {
       id: undefined,
-      name: `${__dirname}/data/file1.txt`,
+      name: `/foobar1/${__dirname}/data/file1.txt`,
       datasetId: 'dataset',
       overwrite: false,
       contentMD5: 'contentMD5'
@@ -682,7 +682,7 @@ test.serial.cb('The "files-upload" command should upload a directory of files st
     });
 
     t.true(uploadSpy.calledWith('https://host/upload', 7));
-    t.true(getFileVerificationStreamStub.calledWith(`${__dirname}/file1.txt`, 7));
+    t.true(getFileVerificationStreamStub.calledWith(`${__dirname}/data/file1.txt`, 7));
     t.end();
   };
 

--- a/test/unit/commands/file.test.js
+++ b/test/unit/commands/file.test.js
@@ -591,17 +591,18 @@ test.serial.cb('The "files-upload" command should upload a directory of files to
     if (postStub.callCount !== 2) {
       return;
     }
+    // NOTE - __dirname will have a leading / and the getRemoteFileName method avoids duplicating /
     t.is(postStub.callCount, 2);
     t.deepEqual(postStub.getCall(0).args[2], {
       id: undefined,
-      name: `/foobar1/${__dirname}/data/file1.txt`,
+      name: `/foobar1${__dirname}/data/file1.txt`,
       datasetId: 'dataset',
       overwrite: false,
       contentMD5: 'contentMD5'
     });
     t.deepEqual(postStub.getCall(1).args[2], {
       id: undefined,
-      name: `/foobar1/${__dirname}/data/file2.txt`,
+      name: `/foobar1${__dirname}/data/file2.txt`,
       datasetId: 'dataset',
       overwrite: false,
       contentMD5: 'contentMD5'

--- a/test/unit/commands/file.test.js
+++ b/test/unit/commands/file.test.js
@@ -668,21 +668,21 @@ test.serial.cb('The "files-upload" command should upload a directory of files st
     t.is(postStub.callCount, 2);
     t.deepEqual(postStub.getCall(0).args[2], {
       id: undefined,
-      name: `file1.txt`,
+      name: `/file1.txt`,
       datasetId: 'dataset',
       overwrite: false,
       contentMD5: 'contentMD5'
     });
     t.deepEqual(postStub.getCall(1).args[2], {
       id: undefined,
-      name: `file2.txt`,
+      name: `/file2.txt`,
       datasetId: 'dataset',
       overwrite: false,
       contentMD5: 'contentMD5'
     });
 
     t.true(uploadSpy.calledWith('https://host/upload', 7));
-    t.true(getFileVerificationStreamStub.calledWith(`${__dirname}/data/file1.txt`, 7));
+    t.true(getFileVerificationStreamStub.calledWith(`${__dirname}/file1.txt`, 7));
     t.end();
   };
 


### PR DESCRIPTION
**Build**: https://travis-ci.org/taylordeatri/cli/builds/609058715?utm_medium=notification&utm_source=email

This change adds 2 options to files upload command:

1) --strip-paths
            This removes the local folder reference passed as the 1st argument from the remote path.
            The result is files / folders would start under the paths
2) --remote-path
            This sets the remote target path to put the file(s) into on the LO server.
Combined these allow you to reference local paths but strip them from the destination path and allow you to specify the target folder path to put the file(s) in.

This will greatly increase control over where you specify local files to upload and where they are stored on the server.