### PR TITLE
Use auth tokens from environment variables if present

### DIFF
--- a/lib/interceptor/tokenProvider.js
+++ b/lib/interceptor/tokenProvider.js
@@ -7,7 +7,7 @@ const { tokenPost } = require('../oauth');
 
 async function getToken () {
   const environment = config.getEnvironment();
-  let accessToken = config.get(`${environment}.tokens.accessToken`);
+  let accessToken = config.get(`${environment}.tokens.accessToken`) || process.env.PHC_ACCESS_TOKEN;
   const defaults = config.get(`${environment}.defaults`);
 
   if (!accessToken && !defaults.useClientCredentials && !defaults.useApiKey) {
@@ -27,7 +27,7 @@ async function getToken () {
 
   if (expired || !accessToken) {
     debug('Token is about to expire. Refreshing...');
-    const refreshToken = config.get(`${environment}.tokens.refreshToken`);
+    const refreshToken = config.get(`${environment}.tokens.refreshToken`) || process.env.PHC_REFRESH_TOKEN;
 
     if (defaults.useClientCredentials) {
       if (!defaults.clientId || !defaults.clientSecret) {


### PR DESCRIPTION
With this, the CLI will just work when running in a notebook much like the python sdk. 