### PR TITLE
Fixing response handling for when using a limit on the genomics list.…

### DIFF
--- a/lib/cmds/genomics_cmds/list-copy-number-sets.js
+++ b/lib/cmds/genomics_cmds/list-copy-number-sets.js
@@ -11,7 +11,7 @@ exports.builder = yargs => {
     describe: 'The dataset id.',
     type: 'string'
   }).option('page-size', {
-    describe: 'Page size',
+    describe: 'Page size, limit max of 1000',
     type: 'number',
     alias: 'n',
     default: 25
@@ -20,7 +20,7 @@ exports.builder = yargs => {
     alias: 't',
     type: 'string'
   }).option('limit', {
-    describe: 'The maximum number of items to return',
+    describe: 'The maximum number of items to return, will override page size',
     alias: 'l',
     type: 'number'
   }).option('status', {
@@ -83,8 +83,8 @@ exports.handler = async argv => {
 
   if (argv.limit) {
     const response = await list(argv, `/copynumbersets/search`, body, 'copyNumberSets');
-    response.data.copyNumberSets = await genomicFilter(response.data.copyNumberSets, argv);
-    print(response, argv);
+    response.copyNumberSets = await genomicFilter(response.copyNumberSets, argv);
+    print(response.copyNumberSets, argv);
   } else {
     body.pageSize = argv.pageSize;
     body.pageToken = argv.nextPageToken;

--- a/lib/cmds/genomics_cmds/list-readgroup-sets.js
+++ b/lib/cmds/genomics_cmds/list-readgroup-sets.js
@@ -11,12 +11,12 @@ exports.builder = yargs => {
     describe: 'The dataset id.',
     type: 'string'
   }).option('page-size', {
-    describe: 'Page size',
+    describe: 'Page size, limit max of 1000',
     type: 'number',
     alias: 'n',
     default: 25
   }).option('limit', {
-    describe: 'The maximum number of items to return',
+    describe: 'The maximum number of items to return, will override page size',
     alias: 'l',
     type: 'number'
   }).option('next-page-token', {
@@ -56,8 +56,8 @@ exports.handler = async argv => {
     const response = await list(argv, `/readgroupsets/search`, {
       datasetIds: [argv.datasetId]
     }, 'readGroupSets');
-    response.data.readGroupSets = await genomicFilter(response.data.readGroupSets, argv);
-    print(response, argv);
+    response.readGroupSets = await genomicFilter(response.readGroupSets, argv);
+    print(response.readGroupSets, argv);
   } else {
     const response = await post(argv, `/readgroupsets/search`, {
       datasetIds: [argv.datasetId],

--- a/lib/cmds/genomics_cmds/list-rna-quantification-sets.js
+++ b/lib/cmds/genomics_cmds/list-rna-quantification-sets.js
@@ -11,7 +11,7 @@ exports.builder = yargs => {
     describe: 'The dataset id.',
     type: 'string'
   }).option('page-size', {
-    describe: 'Page size',
+    describe: 'Page size, limit max of 1000',
     type: 'number',
     alias: 'n',
     default: 25
@@ -20,7 +20,7 @@ exports.builder = yargs => {
     alias: 't',
     type: 'string'
   }).option('limit', {
-    describe: 'The maximum number of items to return',
+    describe: 'The maximum number of items to return, will override page size',
     alias: 'l',
     type: 'number'
   }).option('status', {
@@ -83,8 +83,8 @@ exports.handler = async argv => {
 
   if (argv.limit) {
     const response = await list(argv, `/rnaquantificationsets/search`, body, 'rnaQuantificationSets');
-    response.data.rnaQuantificationSets = await genomicFilter(response.data.rnaQuantificationSets, argv);
-    print(response, argv);
+    response.rnaQuantificationSets = await genomicFilter(response.rnaQuantificationSets, argv);
+    print(response.rnaQuantificationSets, argv);
   } else {
     body.pageSize = argv.pageSize;
     body.pageToken = argv.nextPageToken;

--- a/lib/cmds/genomics_cmds/list-structural-variant-sets.js
+++ b/lib/cmds/genomics_cmds/list-structural-variant-sets.js
@@ -11,7 +11,7 @@ exports.builder = yargs => {
     describe: 'The dataset id.',
     type: 'string'
   }).option('page-size', {
-    describe: 'Page size',
+    describe: 'Page size, limit max of 1000',
     type: 'number',
     alias: 'n',
     default: 25
@@ -20,7 +20,7 @@ exports.builder = yargs => {
     alias: 't',
     type: 'string'
   }).option('limit', {
-    describe: 'The maximum number of items to return',
+    describe: 'The maximum number of items to return, will override page size',
     alias: 'l',
     type: 'number'
   }).option('status', {
@@ -83,8 +83,8 @@ exports.handler = async argv => {
 
   if (argv.limit) {
     const response = await list(argv, `/fusionsets/search`, body, 'fusionSets');
-    response.data.fusionSets = await genomicFilter(response.data.fusionSets, argv);
-    print(response, argv);
+    response.fusionSets = await genomicFilter(response.fusionSets, argv);
+    print(response.fusionSets, argv);
   } else {
     body.pageSize = argv.pageSize;
     body.pageToken = argv.nextPageToken;

--- a/lib/cmds/genomics_cmds/list-variant-sets.js
+++ b/lib/cmds/genomics_cmds/list-variant-sets.js
@@ -11,7 +11,7 @@ exports.builder = yargs => {
     describe: 'The dataset id.',
     type: 'string'
   }).option('page-size', {
-    describe: 'Page size',
+    describe: 'Page size, limit max of 1000',
     type: 'number',
     alias: 'n',
     default: 25
@@ -20,7 +20,7 @@ exports.builder = yargs => {
     alias: 't',
     type: 'string'
   }).option('limit', {
-    describe: 'The maximum number of items to return',
+    describe: 'The maximum number of items to return, will override page size',
     alias: 'l',
     type: 'number'
   }).option('status', {
@@ -83,8 +83,8 @@ exports.handler = async argv => {
 
   if (argv.limit) {
     const response = await list(argv, `/variantsets/search`, body, 'variantSets');
-    response.data.variantSets = await genomicFilter(response.data.variantSets, argv);
-    print(response, argv);
+    response.variantSets = await genomicFilter(response.variantSets, argv);
+    print(response.variantSets, argv);
   } else {
     body.pageSize = argv.pageSize;
     body.pageToken = argv.nextPageToken;


### PR DESCRIPTION
Fixing response handling for when using a limit on the genomics list.  Updating help for clarity.  The response object being different from genomics seems a bit like an anti-pattern, but I'd rather handle it hear to get cli working then dig into possibly breaking/updating the UI due to updating the api