### PR TITLE
Improve data export with the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ pids
 .idea
 
 build/
+life-data/
 work/
 target/
 .git/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 version: 1.0
 node_js:
-- '8'
-- '9'
-- '10'
+- '12'
 script:
   - yarn test
   - yarn build
@@ -19,14 +17,15 @@ deploy:
       secure: KYMQMuUnUHY50XwLwg6Gt9hzFtuXPrT1bSl54r63YoZ1cIRIVFJSUMdwxbA5zWLtt9qzT6TwBj8/6LV+20vdMuN1LAXxO//cOqlJ36THreIGTa97AxBvxpi+yQWscCYWXJU2R8Jpc/cAORS26C4UzNolSqczYd5tuNxKjFRe9+GgqqOl5kXpjgQZXAwXYvnHYSS4DLtkFQw1KgLMeEUocp1owk8XzFkY4Cd9TmStgG80slVyFFFrNoseuPqPpAsmYfGGylGGkLhJ9IeoQWtBhOf8c9hhyic7zBlIyA+BJXIwrhVKBcsjGtMD2An36IeJ2uW25WT3Ok3cenD3JKvvIJoi3vORiOQBP1/vyemNPnysYwh8CeZmz3Rma4x5eN1DICgqBvCje2xw+5qAdqqQq+lClefdPQJwY2CQSEvh3JS6JTCyKDTkzQSyalbD20aT05/C8OGuZL24aXuvf/m1cyRJjKxKwdOR2OBh44xQwc7Oi5qN12lDlbnk7iniUzHa5fpcfglDwgiq1nPaDzyciIUv1mRwBAJMAeNr3DCS1IHZ3Ah0rsntZvYUgPMemsnib2UdZ8KvJfQjRDscQrNotCwClz1c2OkkqFrmeMSU2n/u4dJIA5nHAglqqGl3gkfM9VEEVcuHneHY8Tn6vTq+s9t4Y9NtmMtdyuSEhiVUQh4=
     file:
       - target/lo-linux-x64.zip
-      - target/lo-linux-x86.zip
       - target/lo-macos-x64.zip
       - target/lo-windows-x64.zip
-      - target/lo-windows-x86.zip
+      - target/life-export-linux-x64.zip
+      - target/life-export-macos-x64.zip
+      - target/life-export-windows-x64.zip
     on:
       repo: lifeomic/cli
       tags: true
-      node: '8'
+      node: '12'
   - edge: true
     provider: npm
     email: $NPM_EMAIL
@@ -35,4 +34,4 @@ deploy:
     on:
       tags: true
       repo: lifeomic/cli
-      node: '8'
+      node: '12'

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ interactive terminal or in a scripted environment.
 
 ### Dependencies
 
-* [node](https://nodejs.org) version >= 7.6.0
+* [node](https://nodejs.org) version >= 12.0.0
 
 ### Installation
 

--- a/build.sh
+++ b/build.sh
@@ -9,15 +9,10 @@ node_modules/.bin/pkg --target node12-linux-x64 --output target/linux-x64/lo pac
 node_modules/.bin/pkg --target node12-win-x64 --output target/windows-x64/lo.exe package.json
 node_modules/.bin/pkg --target node12-macos-x64 --output target/macos-x64/lo package.json
 
-(cd target/linux-x64 && zip -q -9 ../lo-linux-x64.zip lo)
-(cd target/windows-x64 && zip -q -9 ../lo-windows-x64.zip lo.exe)
-(cd target/macos-x64 && zip -q -9 ../lo-macos-x64.zip lo)
-
 node_modules/.bin/pkg --target node12-linux-x64 --output target/linux-x64/life-export life-export.js
 node_modules/.bin/pkg --target node12-win-x64 --output target/windows-x64/life-export.exe life-export.js
 node_modules/.bin/pkg --target node12-macos-x64 --output target/macos-x64/life-export life-export.js
 
-(cd target/linux-x64 && zip -q -9 ../life-export-linux-x64.zip life-export)
-(cd target/windows-x64 && zip -q -9 ../life-export-windows-x64.zip life-export.exe)
-(cd target/macos-x64 && zip -q -9 ../life-export-macos-x64.zip life-export)
-
+(cd target/linux-x64 && zip -q -9 ../lo-linux-x64.zip lo life-export)
+(cd target/windows-x64 && zip -q -9 ../lo-windows-x64.zip lo.exe life-export.exe)
+(cd target/macos-x64 && zip -q -9 ../lo-macos-x64.zip lo life-export)

--- a/build.sh
+++ b/build.sh
@@ -5,17 +5,17 @@ set -x
 rm -rf target
 mkdir -p target
 
-node_modules/.bin/pkg --target node8-linux-x64 --output target/linux-x64/lo package.json
-node_modules/.bin/pkg --target node8-win-x64 --output target/windows-x64/lo.exe package.json
-node_modules/.bin/pkg --target node8-macos-x64 --output target/macos-x64/lo package.json
+node_modules/.bin/pkg --target node12-linux-x64 --output target/linux-x64/lo package.json
+node_modules/.bin/pkg --target node12-win-x64 --output target/windows-x64/lo.exe package.json
+node_modules/.bin/pkg --target node12-macos-x64 --output target/macos-x64/lo package.json
 
 (cd target/linux-x64 && zip -q -9 ../lo-linux-x64.zip lo)
 (cd target/windows-x64 && zip -q -9 ../lo-windows-x64.zip lo.exe)
 (cd target/macos-x64 && zip -q -9 ../lo-macos-x64.zip lo)
 
-node_modules/.bin/pkg --target node10-linux-x64 --output target/linux-x64/life-export life-export.js
-node_modules/.bin/pkg --target node10-win-x64 --output target/windows-x64/life-export.exe life-export.js
-node_modules/.bin/pkg --target node10-macos-x64 --output target/macos-x64/life-export life-export.js
+node_modules/.bin/pkg --target node12-linux-x64 --output target/linux-x64/life-export life-export.js
+node_modules/.bin/pkg --target node12-win-x64 --output target/windows-x64/life-export.exe life-export.js
+node_modules/.bin/pkg --target node12-macos-x64 --output target/macos-x64/life-export life-export.js
 
 (cd target/linux-x64 && zip -q -9 ../life-export-linux-x64.zip life-export)
 (cd target/windows-x64 && zip -q -9 ../life-export-windows-x64.zip life-export.exe)

--- a/build.sh
+++ b/build.sh
@@ -6,13 +6,18 @@ rm -rf target
 mkdir -p target
 
 node_modules/.bin/pkg --target node8-linux-x64 --output target/linux-x64/lo package.json
-node_modules/.bin/pkg --target node8-linux-x86 --output target/linux-x86/lo package.json
 node_modules/.bin/pkg --target node8-win-x64 --output target/windows-x64/lo.exe package.json
-node_modules/.bin/pkg --target node8-win-x86 --output target/windows-x86/lo.exe package.json
 node_modules/.bin/pkg --target node8-macos-x64 --output target/macos-x64/lo package.json
 
 (cd target/linux-x64 && zip -q -9 ../lo-linux-x64.zip lo)
-(cd target/linux-x86 && zip -q -9 ../lo-linux-x86.zip lo)
 (cd target/windows-x64 && zip -q -9 ../lo-windows-x64.zip lo.exe)
-(cd target/windows-x86 && zip -q -9 ../lo-windows-x86.zip lo.exe)
 (cd target/macos-x64 && zip -q -9 ../lo-macos-x64.zip lo)
+
+node_modules/.bin/pkg --target node10-linux-x64 --output target/linux-x64/life-export life-export.js
+node_modules/.bin/pkg --target node10-win-x64 --output target/windows-x64/life-export.exe life-export.js
+node_modules/.bin/pkg --target node10-macos-x64 --output target/macos-x64/life-export life-export.js
+
+(cd target/linux-x64 && zip -q -9 ../life-export-linux-x64.zip life-export)
+(cd target/windows-x64 && zip -q -9 ../life-export-windows-x64.zip life-export.exe)
+(cd target/macos-x64 && zip -q -9 ../life-export-macos-x64.zip life-export)
+

--- a/lib/cmds/setup.js
+++ b/lib/cmds/setup.js
@@ -123,7 +123,7 @@ exports.handler = async argv => {
   const environment = argv.environment || answers.environment;
   config.set(`defaults.environment`, environment);
   config.set(`${environment}.defaults.account`, argv.account || answers.account);
-  config.set(`${environment}.defaults.useClientCredentials`, argv.clientId !== undefined || answers.useClientCredentials || false);
+  config.set(`${environment}.defaults.useClientCredentials`, (argv.clientId !== undefined && argv.clientSecret !== undefined) || answers.useClientCredentials || false);
   if (argv.clientId !== undefined || answers.clientId) {
     config.set(`${environment}.defaults.clientId`, argv.clientId || answers.clientId);
   }

--- a/life-export.js
+++ b/life-export.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+const _get = require('lodash/get');
+const chalk = require('chalk');
+const execa = require('execa');
+const fs = require('fs');
+const mkdirp = require('mkdirp');
+const os = require('os');
+
+const DATA_DIR = 'life-data';
+const LIFE_PROJECT = 'f82a69fb-3f0c-4405-9b7f-8df05aaec159';
+const LO = os.platform() === 'win32' ? 'lo.exe' : './lo';
+
+(async () => {
+  await mkdirp(DATA_DIR);
+  console.log(chalk.green('LIFE data will be exported into directory named:'), chalk.bold(DATA_DIR));
+
+  console.log(chalk.green('Configuring with defaults...'));
+  const defaults = execa(LO, [
+    'setup',
+    '--environment',
+    'prod-us',
+    '--account',
+    'lifeomiclife',
+    '--clientId',
+    '2qt93qphnctjbs9ftdpjhvgkl1'
+  ]);
+  defaults.stdout.pipe(process.stdout);
+  await defaults;
+
+  console.log(chalk.green('Authenticating...'));
+  const auth = execa(LO, ['auth']);
+  auth.stdout.pipe(process.stdout);
+  await auth;
+
+  console.log(chalk.green('Fetching FHIR me...'));
+  const me = execa(LO, [
+    'fhir',
+    'me',
+    '--json',
+    '--account',
+    'lifeomiclife'
+  ]);
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  me.stdout.pipe(fs.createWriteStream(`${DATA_DIR}/me.json`));
+  const { stdout: meStdout } = await me;
+
+  const meId = _get(JSON.parse(meStdout), 'entry[0].resource.id');
+  console.log(chalk.green('User Identifier:'), chalk.bold(meId));
+  console.log(chalk.green(`Me exported: ✅`));
+
+  const FHIR_TYPES = ['Procedure', 'Observation', 'Goal'];
+  for (const type of FHIR_TYPES) {
+    console.log(chalk.green(`Fetching ${type}...`));
+    const subprocess = execa(LO, [
+      'fhir',
+      'list',
+      type,
+      '--project',
+      LIFE_PROJECT,
+      `--query`,
+      `subject=${meId}`,
+      '--json',
+      '--account',
+      'lifeomiclife'
+    ]);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    subprocess.stdout.pipe(fs.createWriteStream(`${DATA_DIR}/${type}.json`));
+    await subprocess;
+
+    console.log(chalk.green(`${type} exported: ✅`));
+  }
+  console.log(chalk.green('LIFE data export complete.'));
+})();

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "LifeOmic <development@lifeomic.com>",
   "license": "MIT",
   "engines": {
-    "node": ">= 7.6.0"
+    "node": ">= 12.0.0"
   },
   "bin": "./lo.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
   "engines": {
     "node": ">= 7.6.0"
   },
-  "bin": {
-    "lo": "./lo.js"
-  },
+  "bin": "./lo.js",
   "scripts": {
     "prelint": "yarn --network-timeout 1000000",
     "lint": "eslint .",
@@ -27,6 +25,7 @@
     "configstore": "^3.1.2",
     "copy-paste": "^1.3.0",
     "debug": "^3.2.6",
+    "execa": "^4.0.0",
     "get-stdin": "^6.0.0",
     "inquirer": "^5.2.0",
     "jmespath": "^0.15.0",
@@ -62,6 +61,6 @@
     "access": "public"
   },
   "pkg": {
-    "scripts": "lib/cmds/**/*.js"
+    "scripts": "lib/**/*.js"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1376,6 +1376,15 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
+  integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
@@ -1874,6 +1883,21 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-4.0.0.tgz#7f37d6ec17f09e6b8fc53288611695b6d12b9daf"
+  integrity sha512-JbDUxwV3BoT5ZVXQrSVbAiaXhXUkIwvbhPIwZ0N13kX+5yCzOhUNdocxB/UQRuYOHRYYwAxKYwJYc0T4D12pDA==
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    human-signals "^1.1.1"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.0"
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
@@ -2236,6 +2260,13 @@ get-stream@^4.0.0:
   dependencies:
     pump "^3.0.0"
 
+get-stream@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
+  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
+  dependencies:
+    pump "^3.0.0"
+
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
@@ -2481,6 +2512,11 @@ hullabaloo-config-manager@^1.1.0:
     pkg-dir "^2.0.0"
     resolve-from "^3.0.0"
     safe-buffer "^5.0.1"
+
+human-signals@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
+  integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
 iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@^0.4.8:
   version "0.4.24"
@@ -2913,6 +2949,11 @@ is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
+
+is-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
+  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
 is-symbol@^1.0.2:
   version "1.0.2"
@@ -3456,6 +3497,11 @@ merge-descriptors@~1.0.0:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
 
+merge-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
 merge2@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
@@ -3516,7 +3562,7 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
-mimic-fn@^2.0.0:
+mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
@@ -3719,6 +3765,13 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
+npm-run-path@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
+  dependencies:
+    path-key "^3.0.0"
+
 npmlog@^4.0.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
@@ -3801,6 +3854,13 @@ onetime@^2.0.0:
   integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   dependencies:
     mimic-fn "^1.0.0"
+
+onetime@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
+  integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
+  dependencies:
+    mimic-fn "^2.1.0"
 
 open@^6.3.0:
   version "6.3.0"
@@ -4013,6 +4073,11 @@ path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
+
+path-key@^3.0.0, path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 path-parse@^1.0.5, path-parse@^1.0.6:
   version "1.0.6"
@@ -4694,10 +4759,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
@@ -4992,6 +5069,11 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
+
+strip-final-newline@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
 strip-indent@^1.0.1:
   version "1.0.1"
@@ -5339,6 +5421,13 @@ which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
Improve data export with the CLI by making a single command to run versus
the current 6 step process.

`./life-export` will configure defaults, ask the user to authenticate,
and pull data locally as JSON under a directory named `life-data`.

![image](https://user-images.githubusercontent.com/25412/75346662-2f82c400-586d-11ea-80bb-a0b6b085be37.png)
