### PR TITLE
Fix bin links so 'lo' is available in path after install

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "engines": {
     "node": ">= 12.0.0"
   },
-  "bin": "./lo.js",
+  "bin": {
+    "lo": "./lo.js"
+  },
   "scripts": {
     "prelint": "yarn --network-timeout 1000000",
     "lint": "eslint .",


### PR DESCRIPTION
I noticed after install that bin linking stopped working on the latest version.

It looks like this was unintentionally changed [here](https://github.com/lifeomic/cli/commit/38c5da5f160438413f8a2752c49b53490fa0b1b0#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R11) recently. This reverts a portion of the change so installs work as intended again.

Before this revert, it was linking `cli` instead of `lo` because the above change had removed the explicit name mapping. With no explicit name mapping, the project name was getting used instead of `lo`.