### PR TITLE
Added lo ocr command set

### DIFF
--- a/lib/cmds/ocr.js
+++ b/lib/cmds/ocr.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const options = require('../common-yargs');
+
+exports.command = 'ocr <command>';
+exports.desc = 'Perform operations on OCR.';
+exports.builder = yargs => {
+  return options(yargs.commandDir('ocr_cmds'));
+};
+exports.handler = function (argv) {};

--- a/lib/cmds/ocr_cmds/create-config.js
+++ b/lib/cmds/ocr_cmds/create-config.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const { post } = require('../../api');
+const print = require('../../print');
+
+exports.command = 'create-config <projectId>';
+exports.desc = 'Create an OCR-document in project <projectId>.  JSON queries can be read from stdin.';
+exports.builder = yargs => {
+  yargs.positional('projectId', {
+    describe: 'The ID of the project which will own this cohort for billing purposes.',
+    type: 'string'
+  }).options({
+    denoiserSwitch: {
+      describe: 'Flag for denoiser control. Allowed values: ON|OFF|SMART.',
+      type: 'string'
+    },
+    pathPrefix: {
+      describe: 'Path prefix on file-service where denoised and text files are stored',
+      type: 'string'
+    }
+  });
+};
+
+exports.handler = async argv => {
+  if (argv.denoiserSwitch || argv.pathPrefix) {
+    const response = await post(argv, '/v1/ocr/config', {
+      project: argv.projectId,
+      config: {
+        denoiserSwitch: argv.denoiserSwitch,
+        pathPrefix: argv.pathPrefix
+      }
+    });
+    print(response.data, argv);
+  }
+};

--- a/lib/cmds/ocr_cmds/create-document.js
+++ b/lib/cmds/ocr_cmds/create-document.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const { post } = require('../../api');
+const print = require('../../print');
+
+exports.command = 'create-document <projectId> <subjectId> <fileId>';
+exports.desc = 'Create an OCR-document in project <projectId>.  JSON queries can be read from stdin.';
+exports.builder = yargs => {
+  yargs.positional('projectId', {
+    describe: 'The ID of the project which will own this cohort for billing purposes.',
+    type: 'string'
+  }).positional('subjectId', {
+    describe: 'The ID of subject which the document relates.',
+    type: 'string'
+  }).positional('fileId', {
+    describe: 'The ID of file (file-service ID) that needs OCR.',
+    type: 'string'
+  });
+};
+
+exports.handler = async argv => {
+  const response = await post(argv, `/v1/ocr/documents`, {
+    project: argv.projectId,
+    subject: argv.subjectId,
+    fileId: argv.fileId
+  });
+  print(response.data, argv);
+};

--- a/lib/cmds/ocr_cmds/delete-config.js
+++ b/lib/cmds/ocr_cmds/delete-config.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const { del } = require('../../api');
+const print = require('../../print');
+
+exports.command = 'delete-config <projectId>';
+exports.desc = 'Delete an OCR configuration for <projectId>';
+exports.builder = yargs => {
+  yargs.positional('projectId', {
+    describe: 'The ID of the project to delete.',
+    type: 'string'
+  });
+};
+
+exports.handler = async argv => {
+  await del(argv, `/v1/ocr/config/${argv.projectId}`);
+  print(`Deleted ocr config: ${argv.projectId}`, argv);
+};

--- a/lib/cmds/ocr_cmds/delete-document.js
+++ b/lib/cmds/ocr_cmds/delete-document.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const { del } = require('../../api');
+const print = require('../../print');
+const querystring = require('querystring');
+
+exports.command = 'delete-document <projectId> <id>';
+exports.desc = 'Delete an OCR document by <id>';
+exports.builder = yargs => {
+  yargs.positional('projectId', {
+    describe: 'The ID of the project.',
+    type: 'string'
+  }).positional('id', {
+    describe: 'The ID of the OCR document.',
+    type: 'string'
+  });
+};
+
+exports.handler = async argv => {
+  const opts = {
+    project: argv.projectId
+  };
+  await del(argv, `/v1/ocr/documents/${argv.id}?${querystring.stringify(opts)}`);
+  print(`Deleted ocr document: ${argv.id}`, argv);
+};

--- a/lib/cmds/ocr_cmds/get-config.js
+++ b/lib/cmds/ocr_cmds/get-config.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const { get } = require('../../api');
+const print = require('../../print');
+
+exports.command = 'get-config <projectId>';
+exports.desc = 'Fetch configuration information for project by <projectId>';
+exports.builder = yargs => {
+  yargs.positional('projectId', {
+    describe: 'The ID of the project.',
+    type: 'string'
+  });
+};
+
+exports.handler = async argv => {
+  const response = await get(argv, `/v1/ocr/config/${argv.projectId}`);
+  print(response.data, argv);
+};

--- a/lib/cmds/ocr_cmds/get-document.js
+++ b/lib/cmds/ocr_cmds/get-document.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const { get } = require('../../api');
+const print = require('../../print');
+const querystring = require('querystring');
+
+exports.command = 'get-document <projectId> <id>';
+exports.desc = 'Fetch OCR document by <id>';
+exports.builder = yargs => {
+  yargs.positional('projectId', {
+    describe: 'The ID of the project.',
+    type: 'string'
+  }).positional('id', {
+    describe: 'The ID of the ICR document.',
+    type: 'string'
+  });
+};
+
+exports.handler = async argv => {
+  const opts = {
+    project: argv.projectId
+  };
+  const response = await get(argv, `/v1/ocr/documents/${argv.id}?${querystring.stringify(opts)}`);
+  print(response.data, argv);
+};

--- a/lib/cmds/ocr_cmds/list-documents.js
+++ b/lib/cmds/ocr_cmds/list-documents.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const querystring = require('querystring');
+const { get } = require('../../api');
+const print = require('../../print');
+const formatPage = require('../../formatPage');
+
+exports.command = 'list-documents <projectId>';
+exports.desc = 'List OCR documents by project <projectId>';
+exports.builder = yargs => {
+  yargs.positional('projectId', {
+    describe: 'The ID of the project to search within.',
+    type: 'string'
+  }).option('subjectId', {
+    describe: 'Filter documents which belongs to <subjectId>',
+    alias: 's',
+    type: 'string'
+  }).option('fileId', {
+    describe: 'Filter documents which belongs to <fileId>',
+    alias: 'f',
+    type: 'string'
+  }).option('documentReferenceId', {
+    describe: 'Filter documents which belongs to <documentReferenceId>',
+    alias: 'd',
+    type: 'string'
+  }).option('page-size', {
+    describe: 'Number of items to return',
+    type: 'number',
+    alias: 'n',
+    default: 25
+  }).option('next-page-token', {
+    describe: 'Next page token',
+    alias: 't',
+    type: 'string'
+  });
+};
+
+exports.handler = async argv => {
+  const opts = {
+    project: argv.projectId,
+    subject: argv.subjectId,
+    fileId: argv.fileId,
+    documentReference: argv.documentReferenceId,
+    pageSize: argv.pageSize,
+    nextPageToken: argv.nextPageToken
+  };
+  const response = await get(argv, `/v1/ocr/documents?${querystring.stringify(opts)}`);
+  print(formatPage(response.data), argv);
+};

--- a/test/unit/commands/ocr/config-test.js
+++ b/test/unit/commands/ocr/config-test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const yargs = require('yargs');
+const sinon = require('sinon');
+const test = require('ava');
+const proxyquire = require('proxyquire');
+
+const getStub = sinon.stub();
+const postStub = sinon.stub();
+const delStub = sinon.stub();
+const printSpy = sinon.spy();
+const readStub = sinon.stub();
+let callback;
+
+const mocks = {
+  '../../api': {
+    get: getStub,
+    post: postStub,
+    del: delStub
+  },
+  '../../print': (data, opts) => {
+    printSpy(data, opts);
+    callback();
+  },
+  '../../read': async () => readStub()
+};
+
+const get = proxyquire('../../../../lib/cmds/ocr_cmds/get-config', mocks);
+const del = proxyquire('../../../../lib/cmds/ocr_cmds/delete-config', mocks);
+const create = proxyquire('../../../../lib/cmds/ocr_cmds/create-config', mocks);
+
+test.afterEach.always(t => {
+  getStub.resetHistory();
+  delStub.resetHistory();
+  postStub.resetHistory();
+  printSpy.resetHistory();
+  readStub.resetHistory();
+  callback = null;
+});
+
+test.serial.cb('The "ocr get-config" command should get an ocr config', t => {
+  const res = { data: {} };
+  getStub.onFirstCall().returns(res);
+  callback = () => {
+    t.is(getStub.callCount, 1);
+    t.is(getStub.getCall(0).args[1], '/v1/ocr/config/1');
+    t.is(printSpy.callCount, 1);
+    t.is(printSpy.getCall(0).args[0], res.data);
+    t.end();
+  };
+
+  yargs.command(get)
+    .parse('get-config 1');
+});
+
+test.serial.cb('The "ocr create-config" command should create an ocr config', t => {
+  const res = { data: {} };
+  postStub.onFirstCall().returns(res);
+  const data = {
+    project: '0a14cd67-00ad-4f58-a197-46f67874d300',
+    config: {
+      denoiserSwitch: 'SMART',
+      pathPrefix: 'ocr-test'
+    }
+  };
+  callback = () => {
+    t.is(postStub.callCount, 1);
+    t.is(postStub.getCall(0).args[1], '/v1/ocr/config');
+    t.deepEqual(postStub.getCall(0).args[2], data);
+    t.is(printSpy.callCount, 1);
+    t.is(printSpy.getCall(0).args[0], res.data);
+    t.end();
+  };
+
+  yargs.command(create)
+    .parse('create-config 0a14cd67-00ad-4f58-a197-46f67874d300 --denoiserSwitch "SMART" --pathPrefix "ocr-test"');
+});
+
+test.serial.cb('The "ocr delete-config" command should remove ocr config', t => {
+  callback = () => {
+    t.is(delStub.callCount, 1);
+    t.is(delStub.getCall(0).args[1], '/v1/ocr/config/1');
+    t.is(printSpy.callCount, 1);
+    t.deepEqual(printSpy.getCall(0).args[0], 'Deleted ocr config: 1');
+    t.end();
+  };
+
+  yargs.command(del)
+    .parse('delete-config 1');
+});

--- a/test/unit/commands/ocr/documents-test.js
+++ b/test/unit/commands/ocr/documents-test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const yargs = require('yargs');
+const sinon = require('sinon');
+const test = require('ava');
+const proxyquire = require('proxyquire');
+
+const getStub = sinon.stub();
+const postStub = sinon.stub();
+const delStub = sinon.stub();
+const printSpy = sinon.spy();
+const readStub = sinon.stub();
+let callback;
+
+const mocks = {
+  '../../api': {
+    get: getStub,
+    post: postStub,
+    del: delStub
+  },
+  '../../print': (data, opts) => {
+    printSpy(data, opts);
+    callback();
+  },
+  '../../read': async () => readStub()
+};
+
+const list = proxyquire('../../../../lib/cmds/ocr_cmds/list-documents', mocks);
+const get = proxyquire('../../../../lib/cmds/ocr_cmds/get-document', mocks);
+const del = proxyquire('../../../../lib/cmds/ocr_cmds/delete-document', mocks);
+const create = proxyquire('../../../../lib/cmds/ocr_cmds/create-document', mocks);
+
+test.afterEach.always(t => {
+  getStub.resetHistory();
+  delStub.resetHistory();
+  postStub.resetHistory();
+  printSpy.resetHistory();
+  readStub.resetHistory();
+  callback = null;
+});
+
+test.serial.cb('The "ocr list-document" command should list documents', t => {
+  const res = { data: { items: [] } };
+  getStub.onFirstCall().returns(res);
+  callback = () => {
+    t.is(getStub.callCount, 1);
+    t.is(getStub.getCall(0).args[1], '/v1/ocr/documents?project=project-id&subject=subject-id&fileId=&documentReference=&pageSize=25&nextPageToken=');
+    t.is(printSpy.callCount, 1);
+    t.deepEqual(printSpy.getCall(0).args[0], { items: [] });
+    t.end();
+  };
+
+  yargs.command(list)
+    .parse('list-documents project-id -s subject-id');
+});
+
+test.serial.cb('The "ocr get-document" command should get an ocr document', t => {
+  const res = { data: {} };
+  getStub.onFirstCall().returns(res);
+  callback = () => {
+    t.is(getStub.callCount, 1);
+    t.is(getStub.getCall(0).args[1], '/v1/ocr/documents/document-id?project=project-id');
+    t.is(printSpy.callCount, 1);
+    t.is(printSpy.getCall(0).args[0], res.data);
+    t.end();
+  };
+
+  yargs.command(get)
+    .parse('get-document project-id document-id');
+});
+
+test.serial.cb('The "ocr create-document" command should create an ocr document', t => {
+  const res = { data: {} };
+  postStub.onFirstCall().returns(res);
+  const data = {
+    project: 'project-id',
+    subject: 'subject-id',
+    fileId: 'file-id'
+  };
+  callback = () => {
+    t.is(postStub.callCount, 1);
+    t.is(postStub.getCall(0).args[1], '/v1/ocr/documents');
+    t.deepEqual(postStub.getCall(0).args[2], data);
+    t.is(printSpy.callCount, 1);
+    t.is(printSpy.getCall(0).args[0], res.data);
+    t.end();
+  };
+
+  yargs.command(create)
+    .parse('create-document project-id subject-id file-id');
+});
+
+test.serial.cb('The "ocr delete-document" command should remove ocr document', t => {
+  callback = () => {
+    t.is(delStub.callCount, 1);
+    t.is(delStub.getCall(0).args[1], '/v1/ocr/documents/document-id?project=project-id');
+    t.is(printSpy.callCount, 1);
+    t.deepEqual(printSpy.getCall(0).args[0], 'Deleted ocr document: document-id');
+    t.end();
+  };
+
+  yargs.command(del)
+    .parse('delete-document project-id document-id');
+});


### PR DESCRIPTION
Expanded CLI with commands to interact with OCR feature in PHC. Added ability to configure and initiate OCR. New commands include:
* `create-config`, `get-config` and `delete-config`
* `create-document`, `list-document`, `get-document` and `delete-document`
