### PR TITLE
CR-569: add in output folder handling for workflows

### DIFF
--- a/lib/cmds/workflows_cmds/create.js
+++ b/lib/cmds/workflows_cmds/create.js
@@ -34,6 +34,11 @@ exports.builder = yargs => {
     alias: 'd',
     type: 'string',
     demandOption: false
+  }).option('output-project-folder', {
+    describe: 'Provide a custom path within PHC for workflow outputs to be uploaded',
+    alias: 'p',
+    type: 'string',
+    demandOption: false
   });
 };
 
@@ -47,22 +52,30 @@ exports.handler = async argv => {
 
   if (argv.workflowInputs) {
     const inputs = JSON.parse(argv.workflowInputs);
-    const response = await post(argv, `/workflows/ga4gh/wes/runs`, {
+    const payload = {
       datasetId: argv.datasetId,
       name: argv.name,
       workflowSourceFileId: argv.workflowFileId,
       workflowInputs: inputs,
-      workflowDependenciesFileIds: dependencies
-    });
+      outputProjectFolder: argv.outputProjectFolder
+    };
+    if (argv.workflowDependenciesFileIds) {
+      payload.workflowDependenciesFileIds = dependencies;
+    }
+    const response = await post(argv, `/workflows/ga4gh/wes/runs`, payload);
     print(response.data, argv);
   } else {
-    const response = await post(argv, `/workflows/ga4gh/wes/runs`, {
+    const payload = {
       datasetId: argv.datasetId,
       name: argv.name,
       workflowSourceFileId: argv.workflowFileId,
       workflowInputsFileId: argv.workflowInputsFileId,
-      workflowDependenciesFileIds: dependencies
-    });
+      outputProjectFolder: argv.outputProjectFolder
+    };
+    if (argv.workflowDependenciesFileIds) {
+      payload.workflowDependenciesFileIds = dependencies;
+    }
+    const response = await post(argv, `/workflows/ga4gh/wes/runs`, payload);
     print(response.data, argv);
   }
 };

--- a/test/unit/commands/workflows/workflow-test.js
+++ b/test/unit/commands/workflows/workflow-test.js
@@ -50,7 +50,8 @@ test.serial.cb('The "create" command should create a workflow when using input f
     name: 'template_name',
     workflowSourceFileId: 'workflow-id',
     workflowInputsFileId: 'inputs-file-id',
-    workflowDependenciesFileIds: ['dependency-file-1', 'dependency-file-2']
+    workflowDependenciesFileIds: ['dependency-file-1', 'dependency-file-2'],
+    outputProjectFolder: 'my/cool/path'
   };
 
   callback = () => {
@@ -61,7 +62,7 @@ test.serial.cb('The "create" command should create a workflow when using input f
   };
 
   yargs.command(create)
-    .parse('create dataset -n template_name -w workflow-id -f inputs-file-id -d dependency-file-1,dependency-file-2');
+    .parse('create dataset -n template_name -p my/cool/path -w workflow-id -f inputs-file-id -d dependency-file-1,dependency-file-2');
 });
 
 test.serial.cb('The "delete" should delete a workflow', t => {


### PR DESCRIPTION
Added in a flag for the output folder for workflows and fixed an issue where workflow dependency files were required when they shouldn't be.