### PR TITLE
PHC-761 - update CLI cohort create to use subjectId array instead of query property

### DIFF
--- a/lib/cmds/cohorts_cmds/create.js
+++ b/lib/cmds/cohorts_cmds/create.js
@@ -30,7 +30,7 @@ exports.handler = async argv => {
     name: argv.name,
     description: argv.description,
     ownerProject: argv.projectId,
-    queries: await read(argv)
+    subjectIds: await read(argv)
   });
   print(response.data, argv);
 };

--- a/test/unit/commands/cohorts-test.js
+++ b/test/unit/commands/cohorts-test.js
@@ -87,20 +87,7 @@ test.serial.cb('The "cohorts-get" command should get a cohort', t => {
 test.serial.cb('The "cohorts-create" command should create a cohort', t => {
   const res = { data: {} };
   postStub.onFirstCall().returns(res);
-  const data = [
-    {
-      project: '0a14cd67-00ad-4f58-a197-46f67874d300',
-      queryType: 'JSON',
-      query: {
-        query: {
-          domain: 'filter',
-          target: 'patient'
-        },
-        dataset_id: '0a14cd67-00ad-4f58-a197-46f67874d300'
-      }
-    }
-  ]
-  ;
+  const data = ['06145c42-0625-4dc4-92c7-dbf600e7866a'];
   readStub.onFirstCall().returns(data);
   callback = () => {
     t.is(postStub.callCount, 1);
@@ -109,7 +96,7 @@ test.serial.cb('The "cohorts-create" command should create a cohort', t => {
       name: 'Cohort Name',
       description: 'Cohort Description',
       ownerProject: '1',
-      queries: data
+      subjectIds: data
     });
     t.is(printSpy.callCount, 1);
     t.is(printSpy.getCall(0).args[0], res.data);


### PR DESCRIPTION
This removes the madness Anthony encountered, and uses the new `subjectIds` array field. It will have to wait until https://github.com/lifeomic/cohorts-service/pull/20 is merged before it can ship.

(Anthony's original query of 
```
lo fhir list Patient --project=11111111-2222-3333-4444-30a937adebf7 --query="identifier=77,11,23" --json | jq '[{"project":"11111111-2222-3333-4444-30a937adebf7","queryType":"JSON","query":{"query":{"where":{"patient":{"patients":[.[].id]}},"domain":"filter","target":"patient"},"dataset_id":"11111111-2222-3333-4444-30a937adebf7"}}]' | lo cohorts create -p 11111111-2222-3333-4444-30a937adebf7 "My fancy cohort"
```
 can be simplified to 
```
lo fhir list Patient --project=11111111-2222-3333-4444-30a937adebf7 --query="identifier=77,11,23" --json | jq '[.[].id]' | lo cohorts create -p 11111111-2222-3333-4444-30a937adebf7 "My fancy cohort"
```
 with this change)