### PR TITLE
Provide command suggestions on failure.

### DIFF
--- a/lo.js
+++ b/lo.js
@@ -31,6 +31,7 @@ yargs
   .commandDir('lib/cmds')
   .scriptName('lo')
   .demandCommand(1, 'You need at least one command before moving on')
+  .recommendCommands()
   .help()
   .argv;
 


### PR DESCRIPTION
Takes a silent execution failure when running for example: "lo project list", where it should have been 'projects' and provides an output as such: "Did you mean projects?".