### PR TITLE
PHC-718 Add Wait Option To Suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [13.3.0] - 2021-03-30
-
-### Added
-- Added a new `lo ocr get-suggestions` command to get FHIR suggestions from a document
-
 ## [13.2.0] - 2021-03-18
 
 ### Changed
@@ -875,7 +870,6 @@ and `create-nantomics-vcf-import`
 
 - Replaced the `defaults` command with a `setup` command
 
-[13.3.0]: https://github.com/lifeomic/cli/compare/v13.2.0..v13.3.0
 [13.2.0]: https://github.com/lifeomic/cli/compare/v13.1.0..v13.2.0
 [13.1.0]: https://github.com/lifeomic/cli/compare/v13.0.0..v13.1.0
 [13.0.0]: https://github.com/lifeomic/cli/compare/v12.5.10..v13.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.3.0] - 2021-03-30
+
+### Added
+- Added a new `lo ocr get-suggestions` command to get FHIR suggestions from a document
+
 ## [13.2.0] - 2021-03-18
 
 ### Changed
@@ -870,6 +875,7 @@ and `create-nantomics-vcf-import`
 
 - Replaced the `defaults` command with a `setup` command
 
+[13.3.0]: https://github.com/lifeomic/cli/compare/v13.2.0..v13.3.0
 [13.2.0]: https://github.com/lifeomic/cli/compare/v13.1.0..v13.2.0
 [13.1.0]: https://github.com/lifeomic/cli/compare/v13.0.0..v13.1.0
 [13.0.0]: https://github.com/lifeomic/cli/compare/v12.5.10..v13.0.0

--- a/lib/cmds/ocr_cmds/get-suggestions.js
+++ b/lib/cmds/ocr_cmds/get-suggestions.js
@@ -8,8 +8,11 @@ const { get: fhirGet, getAccount } = require('../../fhir');
 const print = require('../../print');
 const sleep = require('../../sleep');
 
+const waitSeconds = 900;
+
 const getStatus = async argv => {
   let status = 'RUNNING';
+  let count = 0;
   do {
     const account = getAccount(argv);
     const url = `/${account}/dstu3/DocumentReference/${argv.documentId}`;
@@ -20,9 +23,11 @@ const getStatus = async argv => {
       break;
     }
     status = _find(tag, {system: 'http://lifeomic.com/ocr/document/status'}).code;
+    count++;
     if (status.includes('RUNNING')) await sleep(1000);
-  } while (status.includes('RUNNING'));
-  return status.includes('ERROR') ? 'ERROR' : 'SUCCESS';
+  } while (status.includes('RUNNING') && count < waitSeconds);
+  if (!status.includes('RUNNING') && !status.includes('ERROR')) status = 'SUCCESS';
+  return status;
 };
 
 const getSuggestions = async (argv, nextPageToken) => {
@@ -198,7 +203,7 @@ exports.builder = yargs => {
   }).option({
     w: {
       alias: 'wait',
-      describe: 'Wait on the document to finish processing, if applicable',
+      describe: 'Wait up to 15 minutes for the document to finish processing, if applicable',
       type: 'boolean'
     }
   });
@@ -207,10 +212,9 @@ exports.builder = yargs => {
 exports.handler = async argv => {
   if (argv.wait) {
     const status = await getStatus(argv);
-    if (status === 'ERROR') {
-      print('Error occurred while fetching document status.', argv);
-      return;
-    }
+    if (status.includes('ERROR')) print('Error occurred while fetching document status.', argv);
+    else if (status.includes('RUNNING')) print('Timeout reached while waiting for document to process', argv);
+    if (status !== 'SUCCESS') return;
   }
   const response = await loadAnalyzeSuggestions(argv);
   if (argv.suggestions) {

--- a/lib/cmds/ocr_cmds/get-suggestions.js
+++ b/lib/cmds/ocr_cmds/get-suggestions.js
@@ -4,10 +4,9 @@ const querystring = require('querystring');
 const moment = require('moment');
 const _find = require('lodash/find');
 const { get } = require('../../api');
-const { get: fhirGet } = require('../../fhir');
+const { get: fhirGet, getAccount } = require('../../fhir');
 const print = require('../../print');
 const sleep = require('../../sleep');
-const { getAccount } = require('../../fhir');
 
 const getStatus = async argv => {
   let status = 'RUNNING';

--- a/lib/cmds/ocr_cmds/get-suggestions.js
+++ b/lib/cmds/ocr_cmds/get-suggestions.js
@@ -2,8 +2,29 @@
 
 const querystring = require('querystring');
 const moment = require('moment');
+const _find = require('lodash/find');
 const { get } = require('../../api');
+const { get: fhirGet } = require('../../fhir');
 const print = require('../../print');
+const sleep = require('../../sleep');
+const { getAccount } = require('../../fhir');
+
+const getStatus = async argv => {
+  let status = 'RUNNING';
+  do {
+    const account = getAccount(argv);
+    const url = `/${account}/dstu3/DocumentReference/${argv.documentId}`;
+    const response = await fhirGet(argv, url);
+    const tag = response.data && response.data.meta && response.data.meta.tag;
+    if (!tag) {
+      status = 'ERROR';
+      break;
+    }
+    status = _find(tag, {system: 'http://lifeomic.com/ocr/document/status'}).code;
+    if (status.includes('RUNNING')) await sleep(1000);
+  } while (status.includes('RUNNING'));
+  return status.includes('ERROR') ? 'ERROR' : 'SUCCESS';
+};
 
 const getSuggestions = async (argv, nextPageToken) => {
   const suggestionsQuery = querystring.stringify({
@@ -175,10 +196,23 @@ exports.builder = yargs => {
       describe: 'Output unformatted suggestions instead of filtered FHIR',
       type: 'boolean'
     }
+  }).option({
+    w: {
+      alias: 'wait',
+      describe: 'Wait on the document to finish processing, if applicable',
+      type: 'boolean'
+    }
   });
 };
 
 exports.handler = async argv => {
+  if (argv.wait) {
+    const status = await getStatus(argv);
+    if (status === 'ERROR') {
+      print('Error occurred while fetching document status.', argv);
+      return;
+    }
+  }
   const response = await loadAnalyzeSuggestions(argv);
   if (argv.suggestions) {
     print(response, argv);

--- a/test/unit/commands/ocr/suggestions-test.js
+++ b/test/unit/commands/ocr/suggestions-test.js
@@ -18,14 +18,14 @@ const mocks = {
     get: getStub
   },
   '../../fhir': {
-    get: fhirGetStub
+    get: fhirGetStub,
+    getAccount: () => 'account'
   },
   '../../print': (data, opts) => {
     printSpy(data, opts);
     callback();
   },
-  '../../sleep': sleepStub,
-  getAccount: () => 'account'
+  '../../sleep': sleepStub
 };
 
 const getSuggestions = proxyquire('../../../../lib/cmds/ocr_cmds/get-suggestions', mocks);

--- a/test/unit/commands/ocr/suggestions-test.js
+++ b/test/unit/commands/ocr/suggestions-test.js
@@ -24,7 +24,8 @@ const mocks = {
     printSpy(data, opts);
     callback();
   },
-  '../../sleep': sleepStub
+  '../../sleep': sleepStub,
+  getAccount: () => 'account'
 };
 
 const getSuggestions = proxyquire('../../../../lib/cmds/ocr_cmds/get-suggestions', mocks);


### PR DESCRIPTION
This adds a wait options to the `get-suggestions` command that causes the cli to wait to fetch suggestions until the document has finished processing. I will update the changelog and version in a separate PR.