### PR TITLE
Add skip additional prompts flag to `lo setup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.4.0] - 2021-07-22
+
+### Added
+- Added `--skipPrompts` flag to `lo setup` command to enable unattended scripting of environment changes
+  - `lo setup -e prod-us --skipPrompts` does not give follow up prompts
+
 ## [13.3.0] - 2021-04-05
 
 ### Added

--- a/lib/cmds/setup.js
+++ b/lib/cmds/setup.js
@@ -37,7 +37,11 @@ exports.builder = yargs => {
     type: 'string'
   }).group(
     ['clientId', 'clientSecret'], 'Use client credentials'
-  );
+  ).option('skipPrompts', {
+    describe: 'Skip interactive follow up prompts\n~/.config/configstore/lifeomic-cli.json must be configured\nRequires "-e" flag in order to skip all prompts',
+    type: 'boolean',
+    alias: 's'
+  });
 };
 
 exports.handler = async argv => {
@@ -56,14 +60,14 @@ exports.handler = async argv => {
       message: 'Specify a default organization account id to use: ',
       validate: input => input.match(/^([a-z0-9]{1,16})$/) ? true : `${input} is not a valid account id`,
       default: a => config.get(`${a.environment}.defaults.account`),
-      when: a => argv.account === undefined
+      when: a => argv.account === undefined && argv.skipPrompts === undefined
     },
     {
       type: 'confirm',
       name: 'useApiKey',
       message: 'Use API key for authentication?',
       default: a => config.get(`${a.environment}.defaults.apiKey`) !== undefined,
-      when: a => argv.apiKey === undefined && argv.authClientId === undefined && argv.clientId === undefined
+      when: a => argv.apiKey === undefined && argv.authClientId === undefined && argv.clientId === undefined && argv.skipPrompts === undefined
     },
     {
       type: 'input',
@@ -77,7 +81,7 @@ exports.handler = async argv => {
       name: 'useAuthClient',
       message: 'Use custom client for authentication?',
       default: a => config.get(`${a.environment}.defaults.authClientId`) !== undefined,
-      when: a => !a.useApiKey && argv.apiKey === undefined && argv.authClientId === undefined && argv.clientId === undefined
+      when: a => !a.useApiKey && argv.apiKey === undefined && argv.authClientId === undefined && argv.clientId === undefined && argv.skipPrompts === undefined
     },
     {
       type: 'input',
@@ -99,7 +103,7 @@ exports.handler = async argv => {
       name: 'useClientCredentials',
       message: 'Use client credentials for authentication?',
       default: a => config.get(`${a.environment}.defaults.clientId`) !== undefined,
-      when: a => !a.useApiKey && !a.useAuthClient && argv.apiKey === undefined && argv.authClientId === undefined && argv.clientId === undefined
+      when: a => !a.useApiKey && !a.useAuthClient && argv.apiKey === undefined && argv.authClientId === undefined && argv.clientId === undefined && argv.skipPrompts === undefined
     },
     {
       type: 'input',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/cli",
-  "version": "13.3.0",
+  "version": "13.4.0",
   "description": "CLI for interacting with the LifeOmic PHC API.",
   "main": "lo.js",
   "author": "LifeOmic <development@lifeomic.com>",


### PR DESCRIPTION
## Description

Currently there is no way to "silence" additional prompts for the `lo setup` command.

When you have `~/.config/configstore/lifeomic-cli.json` configured correctly, there is no reason to force prompts upon the user of the cli tool.

Additional prompts currently look like this:

``` sh
? Use API key for authentication? (y/N)
? Use custom client for authentication? (y/N)
? Use client credentials for authentication? (y/N)
```

And this saves a JSON object in `~/.config/configstore/lifeomic-cli.json`:

``` json
"defaults": {
    "useClientCredentials": false,
    "useAuthClient": false,
    "useApiKey": false
},
```

So after this object gets saved in `~/.config/configstore/lifeomic-cli.json` there is no need to additionally force prompts upon the user.

## Motivation

**Short term:** 
It would be nice to be able to run `lo setup -e dev && lo auth -c` and not get prompts for additional input.


**Long term:**
Ability to script environment changes between `prod-us`, `dev`, etc... or possibly even between user accounts.


### Stretch goals enabled by this PR

This is **Step 1** of a larger plan to allow scripting environment changes or user account changes.

* **Step 1** - This PR
* **Step 2** - Enables: Local *unattended* scripts for automating user/environment changes
* **Step 3** - Enables: Create plugin(s) for API clients such as Insomnia to automate user/environment changes

### Additional backstory

There are cases when switching tokens (i.e. with `lo auth -c`) happens regularly.  For example, if using Insomnia (or other API client), you may wish to run some GraphQL query/mutation on multiple users/environments.

In order to perform these token changes, you have to drop into shell, run some commands, copy the token, paste into API client and finally execute the API call.  Long term stretch goal of this change would allow us to script that user/env change and even create plugins for API clients that make switching even easier.  This would be Step 1 of making that happen.

## Usage

This PR will enable the `-s` or `--skipPrompts` flag and can be used like `lo setup -e dev -s` or to get a bit more out of it, you can do `lo setup -e dev -s && lo auth -c` to get the token in your clipboard immediately.