### PR TITLE
Add refresh token support to 'lo auth'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.5.0] - 2021-07-22
+
+### Added
+- Added `lo auth -r` to support token refresh
+
 ## [13.4.0] - 2021-07-22
 
 ### Added

--- a/lib/cmds/auth.js
+++ b/lib/cmds/auth.js
@@ -4,7 +4,7 @@ const { prompt } = require('inquirer');
 const chalk = require('chalk');
 const { copy } = require('copy-paste');
 const config = require('../config');
-const { login } = require('../oauth');
+const { login, tokenPost } = require('../oauth');
 
 exports.command = 'auth';
 exports.desc = 'Authenticate to the LifeOmic Platform to obtain an access token.';
@@ -15,6 +15,9 @@ exports.builder = yargs => {
   }).option('copy', {
     describe: 'Copies the current access token to the clipboard',
     alias: 'c'
+  }).option('refresh', {
+    describe: 'Refresh the current access token',
+    alias: 'r'
   });
 };
 
@@ -48,6 +51,20 @@ exports.handler = async argv => {
       console.log(chalk.red(`No access token present.  Run 'lo auth'.`));
       process.exit(1);
     }
+  } else if (argv.refresh) {
+    const refreshToken = config.get(`${environment}.tokens.refreshToken`);
+    if (!refreshToken) {
+      throw new Error("Refresh token not set. Run 'lo auth' to obtain one.");
+    }
+    console.log(chalk.green('Refreshing token'));
+    const response = await tokenPost(environment, null, {
+      grant_type: 'refresh_token',
+      client_id: config.get(`${environment}.defaults.useAuthClient`) ? config.get(`${environment}.defaults.authClientId`) : config.get(environment).clientId,
+      refresh_token: refreshToken
+    });
+    const accessToken = response.data.access_token;
+    config.set(`${environment}.tokens.accessToken`, accessToken);
+    console.log(chalk.green('Access token refreshed'));
   } else {
     if (config.get(`${environment}.defaults.useClientCredentials`) || config.get(`${environment}.defaults.useApiKey`)) {
       console.log(chalk.red(`auth command is not allowed for client credentials or API key.`));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/cli",
-  "version": "13.4.0",
+  "version": "13.5.0",
   "description": "CLI for interacting with the LifeOmic PHC API.",
   "main": "lo.js",
   "author": "LifeOmic <development@lifeomic.com>",


### PR DESCRIPTION
Ex: `lo auth -r`

This argument allows the user to re-auth without needing to re-enter their password.