### PR TITLE
PHC-924 Make project required for FHIR list

### DIFF
--- a/lib/cmds/fhir_cmds/list.js
+++ b/lib/cmds/fhir_cmds/list.js
@@ -8,15 +8,16 @@ const url = require('url');
 const jmespath = require('jmespath');
 const fs = require('fs');
 
-exports.command = 'list <type> <project>';
-exports.desc = 'List FHIR resources by type <type> <project>.';
+exports.command = 'list <type>';
+exports.desc = 'List FHIR resources by type <type> --project <projectId>.';
 exports.builder = yargs => {
   yargs.positional('type', {
     describe: 'The FHIR resource type.',
     type: 'string'
-  }).positional('project', {
+  }).option('project', {
     describe: 'Filter by project ID',
-    type: 'string'
+    type: 'string',
+    required: true
   }).option('query', {
     describe: 'Optional FHIR query',
     type: 'string'

--- a/lib/cmds/fhir_cmds/list.js
+++ b/lib/cmds/fhir_cmds/list.js
@@ -8,13 +8,13 @@ const url = require('url');
 const jmespath = require('jmespath');
 const fs = require('fs');
 
-exports.command = 'list <type>';
-exports.desc = 'List FHIR resources by type <type>.';
+exports.command = 'list <type> <project>';
+exports.desc = 'List FHIR resources by type <type> <project>.';
 exports.builder = yargs => {
   yargs.positional('type', {
     describe: 'The FHIR resource type.',
     type: 'string'
-  }).option('project', {
+  }).positional('project', {
     describe: 'Filter by project ID',
     type: 'string'
   }).option('query', {
@@ -129,12 +129,10 @@ exports.handler = async argv => {
     argv.query = {};
   }
 
-  if (argv.project) {
-    if (argv.query['_tag']) {
-      argv.query['_tag'] = _concat(argv.query['_tag'], `http://lifeomic.com/fhir/dataset|${argv.project}`);
-    } else {
-      argv.query['_tag'] = `http://lifeomic.com/fhir/dataset|${argv.project}`;
-    }
+  if (argv.query['_tag']) {
+    argv.query['_tag'] = _concat(argv.query['_tag'], `http://lifeomic.com/fhir/dataset|${argv.project}`);
+  } else {
+    argv.query['_tag'] = `http://lifeomic.com/fhir/dataset|${argv.project}`;
   }
 
   await search(argv.type, argv.query, argv);

--- a/test/unit/commands/fhir-test.js
+++ b/test/unit/commands/fhir-test.js
@@ -65,7 +65,7 @@ test.serial.cb('The "fhir" command should list fhir resources', t => {
   };
 
   yargs.command(list)
-    .parse('list Patient --project projectId');
+    .parse('list Patient projectId');
 });
 
 test.serial.cb('The "fhir" command should list fhir resources with a query expression', t => {
@@ -83,7 +83,7 @@ test.serial.cb('The "fhir" command should list fhir resources with a query expre
   };
 
   yargs.command(list)
-    .parse('list Patient --project projectId --query "_tag=http://lifeomic.com/fhir/tag|value"');
+    .parse('list Patient projectId --query "_tag=http://lifeomic.com/fhir/tag|value"');
 });
 
 test.serial.cb('Limit should set the page size for the "fhir" command', t => {
@@ -93,7 +93,7 @@ test.serial.cb('Limit should set the page size for the "fhir" command', t => {
   callback = () => {
     t.is(postStub.callCount, 1);
     t.is(postStub.getCall(0).args[1], 'account/dstu3/Patient/_search');
-    t.is(postStub.getCall(0).args[2], 'pageSize=10');
+    t.is(postStub.getCall(0).args[2], '_tag=http%3A%2F%2Flifeomic.com%2Ffhir%2Fdataset%7CprojectId&pageSize=10');
     t.deepEqual(postStub.getCall(0).args[3], { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } });
     t.is(printSpy.callCount, 1);
     t.deepEqual(printSpy.getCall(0).args[0], [{ 'resourceType': 'Patient', 'id': 'ABC1234' }]);
@@ -101,7 +101,7 @@ test.serial.cb('Limit should set the page size for the "fhir" command', t => {
   };
 
   yargs.command(list)
-    .parse('list Patient --limit 10');
+    .parse('list Patient projectId --limit 10');
 });
 
 test.serial.cb('The "fhir-ingest" command should update a fhir resource', t => {

--- a/test/unit/commands/fhir-test.js
+++ b/test/unit/commands/fhir-test.js
@@ -65,7 +65,7 @@ test.serial.cb('The "fhir" command should list fhir resources', t => {
   };
 
   yargs.command(list)
-    .parse('list Patient projectId');
+    .parse('list Patient --project projectId');
 });
 
 test.serial.cb('The "fhir" command should list fhir resources with a query expression', t => {
@@ -83,7 +83,7 @@ test.serial.cb('The "fhir" command should list fhir resources with a query expre
   };
 
   yargs.command(list)
-    .parse('list Patient projectId --query "_tag=http://lifeomic.com/fhir/tag|value"');
+    .parse('list Patient --project projectId --query "_tag=http://lifeomic.com/fhir/tag|value"');
 });
 
 test.serial.cb('Limit should set the page size for the "fhir" command', t => {
@@ -101,7 +101,7 @@ test.serial.cb('Limit should set the page size for the "fhir" command', t => {
   };
 
   yargs.command(list)
-    .parse('list Patient projectId --limit 10');
+    .parse('list Patient --project projectId --limit 10');
 });
 
 test.serial.cb('The "fhir-ingest" command should update a fhir resource', t => {


### PR DESCRIPTION
Do this to avoid timeouts on accounts that have multiple projects
when querying