### PR TITLE
Limit fhir list page size to 500

### DIFF
--- a/lib/cmds/fhir_cmds/list.js
+++ b/lib/cmds/fhir_cmds/list.js
@@ -50,10 +50,11 @@ async function search (type, query, options) {
     console.log(header);
   }
 
+  const pageSize = isNaN(limit) ? undefined : Math.min(limit, 500);
   if (query) {
-    query.pageSize = limit;
+    query.pageSize = pageSize;
   } else {
-    query = {pageSize: limit};
+    query = {pageSize: pageSize};
   }
 
   const searchUrl = `${account}/dstu3/${type}/_search`;

--- a/test/unit/commands/fhir-test.js
+++ b/test/unit/commands/fhir-test.js
@@ -57,7 +57,7 @@ test.serial.cb('The "fhir" command should list fhir resources', t => {
   callback = () => {
     t.is(postStub.callCount, 1);
     t.is(postStub.getCall(0).args[1], 'account/dstu3/Patient/_search');
-    t.is(postStub.getCall(0).args[2], '_tag=http%3A%2F%2Flifeomic.com%2Ffhir%2Fdataset%7CprojectId&pageSize=1000');
+    t.is(postStub.getCall(0).args[2], '_tag=http%3A%2F%2Flifeomic.com%2Ffhir%2Fdataset%7CprojectId&pageSize=500');
     t.deepEqual(postStub.getCall(0).args[3], { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } });
     t.is(printSpy.callCount, 1);
     t.deepEqual(printSpy.getCall(0).args[0], [{ 'resourceType': 'Patient', 'id': 'ABC1234' }]);
@@ -75,7 +75,7 @@ test.serial.cb('The "fhir" command should list fhir resources with a query expre
   callback = () => {
     t.is(postStub.callCount, 1);
     t.is(postStub.getCall(0).args[1], 'account/dstu3/Patient/_search');
-    t.is(postStub.getCall(0).args[2], '_tag=http%3A%2F%2Flifeomic.com%2Ffhir%2Ftag%7Cvalue&_tag=http%3A%2F%2Flifeomic.com%2Ffhir%2Fdataset%7CprojectId&pageSize=1000');
+    t.is(postStub.getCall(0).args[2], '_tag=http%3A%2F%2Flifeomic.com%2Ffhir%2Ftag%7Cvalue&_tag=http%3A%2F%2Flifeomic.com%2Ffhir%2Fdataset%7CprojectId&pageSize=500');
     t.deepEqual(postStub.getCall(0).args[3], { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } });
     t.is(printSpy.callCount, 1);
     t.deepEqual(printSpy.getCall(0).args[0], [{ 'resourceType': 'Patient', 'id': 'ABC1234' }]);
@@ -102,6 +102,24 @@ test.serial.cb('Limit should set the page size for the "fhir" command', t => {
 
   yargs.command(list)
     .parse('list Patient --project projectId --limit 10');
+});
+
+test.serial.cb('Limit should restrict to a max page size for the "fhir" command', t => {
+  const res = { data: { entry: [{ 'resource': { 'resourceType': 'Patient', 'id': 'ABC1234' } }] } };
+  postStub.onFirstCall().returns(res);
+
+  callback = () => {
+    t.is(postStub.callCount, 1);
+    t.is(postStub.getCall(0).args[1], 'account/dstu3/Patient/_search');
+    t.is(postStub.getCall(0).args[2], '_tag=http%3A%2F%2Flifeomic.com%2Ffhir%2Fdataset%7CprojectId&pageSize=500');
+    t.deepEqual(postStub.getCall(0).args[3], { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } });
+    t.is(printSpy.callCount, 1);
+    t.deepEqual(printSpy.getCall(0).args[0], [{ 'resourceType': 'Patient', 'id': 'ABC1234' }]);
+    t.end();
+  };
+
+  yargs.command(list)
+    .parse('list Patient --project projectId --limit 10000');
 });
 
 test.serial.cb('The "fhir-ingest" command should update a fhir resource', t => {


### PR DESCRIPTION
@anthonyroach, not sure if this is the most elegant solution here.  We have users leveraging POCR that are hitting body size limits listing observation with the default 1k page size because those resources can be bulky.  it's crossing the body size limit by about 15%.

A few solutions I tossed around:
* expose an explicit page size arg.  This isn't great because it assumes knowledge implementation details.
* lower the default limit in the backend service from 1k to 500.  It seems heavy-handed platform-wide change.

I went with this because it seemed the most straightforward.  The only change for users will be that listing huge collections of resources will take longer.