### PR TITLE
feat: PHC-3861 add genomic ingestion commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.9.0] - 2023-01-04
+
+### Added
+- Added a `lo genomics ingestions` command set with the following commands
+  - `lo genomics ingestions list` Lists genomic ingestions for a project
+  - `lo genomics ingestions get` Gets a genomic ingestions
+  - `lo genomics ingestions create-foundation` Creates a Foundation ingestion
+  - `lo genomics ingestions create-caris` Creates a Caris ingestion
+  - `lo genomics ingestions create-foundation-bam` Creates a Foundation BAM ingestion
+  - `lo genomics ingestions create-caris-bam` Creates a Caris BAM ingestion
+
+## [13.8.1] - 2022-07-25
+
+### Fixed
+- Added `maxBodyLength` for file uploads
+
+## [13.8.0] - 2022-05-24
+
+### Changed
+- `lo surveys export-responses` now supports an optional `query` parameter
+
+## [13.7.0] - 2022-04-06
+
+### Changed
+- Updated how project is published
+
 ## [13.6.0] - 2021-10-06
 
 ### Changed
@@ -891,6 +917,10 @@ and `create-nantomics-vcf-import`
 
 - Replaced the `defaults` command with a `setup` command
 
+[13.9.0]: https://github.com/lifeomic/cli/compare/v13.8.1..v13.9.0
+[13.8.1]: https://github.com/lifeomic/cli/compare/v13.8.0..v13.8.1
+[13.8.0]: https://github.com/lifeomic/cli/compare/v13.7.0..v13.8.0
+[13.7.0]: https://github.com/lifeomic/cli/compare/v13.6.0..v13.7.0
 [13.6.0]: https://github.com/lifeomic/cli/compare/v13.5.0..v13.6.0
 [13.5.0]: https://github.com/lifeomic/cli/compare/v13.4.0..v13.5.0
 [13.4.0]: https://github.com/lifeomic/cli/compare/v13.3.0..v13.4.0

--- a/lib/cmds/genomics_cmds/ingestions.js
+++ b/lib/cmds/genomics_cmds/ingestions.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const options = require('../../common-yargs');
+
+exports.command = 'ingestions <command>';
+exports.desc = 'Perform operations on genomic ingestions.';
+exports.builder = yargs => {
+  return options(yargs.commandDir('ingestions_cmds'));
+};
+exports.handler = function (argv) {};

--- a/lib/cmds/genomics_cmds/ingestions_cmds/create-caris-bam.js
+++ b/lib/cmds/genomics_cmds/ingestions_cmds/create-caris-bam.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const { post } = require('../../../api');
+const print = require('../../../print');
+
+exports.command = 'create-caris-bam <projectId> <bamFileId>';
+exports.desc = 'Create Caris BAM ingestion for <bamFileId> in <projectId>';
+exports.builder = yargs => {
+  yargs.positional('projectId', {
+    describe: 'The project ID.',
+    type: 'string'
+  }).positional('bamFileId', {
+    describe: 'The ID of the BAM file.',
+    type: 'string'
+  }).option('succeededEmail', {
+    describe: 'An email address to notify if the ingestion succeeds',
+    type: 'string'
+  }).option('failedEmail', {
+    describe: 'An email address to notify if the ingestion fails',
+    type: 'string'
+  });
+};
+
+exports.handler = async argv => {
+  const response = await post(argv, `/v1/genomic-ingestion/projects/${argv.projectId}/ingestions`, {
+    ingestionType: 'CarisBam',
+    inputFiles: {
+      bam: argv.bamFileId
+    },
+    notificationConfig: {
+      succeededEmail: argv.succeededEmail,
+      failedEmail: argv.failedEmail
+    }
+  });
+  print(response.data, argv);
+};

--- a/lib/cmds/genomics_cmds/ingestions_cmds/create-caris.js
+++ b/lib/cmds/genomics_cmds/ingestions_cmds/create-caris.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const { post } = require('../../../api');
+const print = require('../../../print');
+
+exports.command = 'create-caris <projectId> <tarFileId>';
+exports.desc = 'Create Caris ingestion for <tarFileId> in <projectId>';
+exports.builder = yargs => {
+  yargs.positional('projectId', {
+    describe: 'The project ID.',
+    type: 'string'
+  }).positional('tarFileId', {
+    describe: 'The ID of the TAR file.',
+    type: 'string'
+  }).option('succeededEmail', {
+    describe: 'An email address to notify if the ingestion succeeds',
+    type: 'string'
+  }).option('failedEmail', {
+    describe: 'An email address to notify if the ingestion fails',
+    type: 'string'
+  });
+};
+
+exports.handler = async argv => {
+  const response = await post(argv, `/v1/genomic-ingestion/projects/${argv.projectId}/ingestions`, {
+    ingestionType: 'Caris',
+    inputFiles: {
+      tar: argv.tarFileId
+    },
+    notificationConfig: {
+      succeededEmail: argv.succeededEmail,
+      failedEmail: argv.failedEmail
+    }
+  });
+  print(response.data, argv);
+};

--- a/lib/cmds/genomics_cmds/ingestions_cmds/create-foundation-bam.js
+++ b/lib/cmds/genomics_cmds/ingestions_cmds/create-foundation-bam.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const { post } = require('../../../api');
+const print = require('../../../print');
+
+exports.command = 'create-foundation-bam <projectId> <bamFileId>';
+exports.desc = 'Create Foundation BAM ingestion for <bamFileId> in <projectId>';
+exports.builder = yargs => {
+  yargs.positional('projectId', {
+    describe: 'The project ID.',
+    type: 'string'
+  }).positional('bamFileId', {
+    describe: 'The ID of the BAM file.',
+    type: 'string'
+  }).option('succeededEmail', {
+    describe: 'An email address to notify if the ingestion succeeds',
+    type: 'string'
+  }).option('failedEmail', {
+    describe: 'An email address to notify if the ingestion fails',
+    type: 'string'
+  });
+};
+
+exports.handler = async argv => {
+  const response = await post(argv, `/v1/genomic-ingestion/projects/${argv.projectId}/ingestions`, {
+    ingestionType: 'FoundationBam',
+    inputFiles: {
+      bam: argv.bamFileId
+    },
+    notificationConfig: {
+      succeededEmail: argv.succeededEmail,
+      failedEmail: argv.failedEmail
+    }
+  });
+  print(response.data, argv);
+};

--- a/lib/cmds/genomics_cmds/ingestions_cmds/create-foundation.js
+++ b/lib/cmds/genomics_cmds/ingestions_cmds/create-foundation.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { post } = require('../../../api');
+const print = require('../../../print');
+
+exports.command = 'create-foundation <projectId> <xmlFileId> <reportFileId> [vcfFileId]';
+exports.desc = 'Create Foundation ingestion for <xmlFileId>, <reportFileId>, and optionally [vcfFileId] in <projectId>';
+exports.builder = yargs => {
+  yargs.positional('projectId', {
+    describe: 'The project ID.',
+    type: 'string'
+  }).positional('xmlFileId', {
+    describe: 'The ID of the XML file.',
+    type: 'string'
+  }).positional('reportFileId', {
+    describe: 'The ID of the report file.',
+    type: 'string'
+  }).positional('vcfFileId', {
+    describe: 'The ID of the VCF file.',
+    type: 'string'
+  }).option('succeededEmail', {
+    describe: 'An email address to notify if the ingestion succeeds',
+    type: 'string'
+  }).option('failedEmail', {
+    describe: 'An email address to notify if the ingestion fails',
+    type: 'string'
+  });
+};
+
+exports.handler = async argv => {
+  const response = await post(argv, `/v1/genomic-ingestion/projects/${argv.projectId}/ingestions`, {
+    ingestionType: 'Foundation',
+    inputFiles: {
+      xml: argv.xmlFileId,
+      vcf: argv.vcfFileId || null,
+      report: argv.reportFileId
+    },
+    notificationConfig: {
+      succeededEmail: argv.succeededEmail,
+      failedEmail: argv.failedEmail
+    }
+  });
+  print(response.data, argv);
+};

--- a/lib/cmds/genomics_cmds/ingestions_cmds/get.js
+++ b/lib/cmds/genomics_cmds/ingestions_cmds/get.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const { get } = require('../../../api');
+const print = require('../../../print');
+
+exports.command = 'get <projectId> <ingestionId>';
+exports.desc = 'Fetch ingestion details by <projectId> and <ingestionId>';
+exports.builder = yargs => {
+  yargs.positional('projectId', {
+    describe: 'The project ID.',
+    type: 'string'
+  }).positional('ingestionId', {
+    describe: 'The ingestion ID.',
+    type: 'string'
+  });
+};
+
+exports.handler = async argv => {
+  const response = await get(argv, `/v1/genomic-ingestion/projects/${argv.projectId}/ingestions/${argv.ingestionId}`);
+  print(response.data, argv);
+};

--- a/lib/cmds/genomics_cmds/ingestions_cmds/list.js
+++ b/lib/cmds/genomics_cmds/ingestions_cmds/list.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const querystring = require('querystring');
+const { get, list } = require('../../../api');
+const print = require('../../../print');
+const formatPage = require('../../../formatPage');
+
+exports.command = 'list <projectId>';
+exports.desc = 'List ingestions by <projectId>';
+exports.builder = yargs => {
+  yargs.positional('projectId', {
+    describe: 'The project ID.',
+    type: 'string'
+  }).option('page-size', {
+    describe: 'The page size.',
+    type: 'number',
+    alias: 'n',
+    default: 25
+  }).option('next-page-token', {
+    describe: 'The next page token.',
+    alias: 't',
+    type: 'string'
+  }).option('limit', {
+    describe: 'The maximum number of items to return.',
+    alias: 'l',
+    type: 'number'
+  }).option('name', {
+    describe: 'Filter ingestions where the ingestion name contains this',
+    type: 'string'
+  }).option('failed', {
+    describe: 'Filter ingestions that have failed',
+    type: 'boolean'
+  }).option('step', {
+    describe: 'Filter ingestions that are on this step',
+    type: 'string',
+    choices: ['AwaitingFiles', 'Submitted', 'Transformed', 'Normalized', 'TestCreated', 'TestNotCreated']
+  });
+};
+
+exports.handler = async argv => {
+  const opts = {
+    projectId: argv.projectId,
+    pageSize: argv.limit ? 1000 : argv.pageSize,
+    nextPageToken: argv.nextPageToken,
+    name: argv.name,
+    failed: argv.failed,
+    steps: argv.step
+  };
+
+  const path = `/v1/genomic-ingestion/projects/${argv.projectId}/ingestions?${querystring.stringify(opts)}`;
+
+  const response = await (argv.limit ? list(argv, path) : get(argv, path));
+  print(formatPage(response.data), argv);
+};

--- a/lib/cmds/genomics_cmds/ingestions_cmds/list.js
+++ b/lib/cmds/genomics_cmds/ingestions_cmds/list.js
@@ -39,13 +39,13 @@ exports.builder = yargs => {
 
 exports.handler = async argv => {
   const opts = {
-    projectId: argv.projectId,
-    pageSize: argv.limit ? 1000 : argv.pageSize,
-    nextPageToken: argv.nextPageToken,
-    name: argv.name,
-    failed: argv.failed,
-    steps: argv.step
+    pageSize: argv.limit ? 1000 : argv.pageSize
   };
+
+  if (argv.nextPageToken) opts.nextPageToken = argv.nextPageToken;
+  if (argv.name) opts.name = argv.name;
+  if (argv.failed) opts.failed = argv.failed;
+  if (argv.step) opts.steps = argv.step;
 
   const path = `/v1/genomic-ingestion/projects/${argv.projectId}/ingestions?${querystring.stringify(opts)}`;
 

--- a/test/unit/commands/genomics-ingestions.test.js
+++ b/test/unit/commands/genomics-ingestions.test.js
@@ -1,0 +1,162 @@
+'use strict';
+
+const yargs = require('yargs');
+const sinon = require('sinon');
+const test = require('ava');
+const proxyquire = require('proxyquire');
+
+const getStub = sinon.stub();
+const postStub = sinon.stub();
+const printSpy = sinon.stub();
+let callback;
+
+const mocks = {
+  '../../../api': {
+    get: getStub,
+    post: postStub
+  },
+  '../../../print': (data, opts) => {
+    printSpy(data, opts);
+    callback();
+  }
+};
+
+const get = proxyquire('../../../lib/cmds/genomics_cmds/ingestions_cmds/get', mocks);
+const list = proxyquire('../../../lib/cmds/genomics_cmds/ingestions_cmds/list', mocks);
+const createFoundation = proxyquire('../../../lib/cmds/genomics_cmds/ingestions_cmds/create-foundation', mocks);
+const createCaris = proxyquire('../../../lib/cmds/genomics_cmds/ingestions_cmds/create-caris', mocks);
+const createFoundationBam = proxyquire('../../../lib/cmds/genomics_cmds/ingestions_cmds/create-foundation-bam', mocks);
+const createCarisBam = proxyquire('../../../lib/cmds/genomics_cmds/ingestions_cmds/create-caris-bam', mocks);
+
+test.always.afterEach(t => {
+  getStub.resetHistory();
+  postStub.resetHistory();
+  printSpy.resetHistory();
+  callback = null;
+});
+
+test.serial.cb('The "get" command should get an ingestion based on project id and ingestion id', t => {
+  const res = { data: { id: 'ingestionId' } };
+  getStub.onFirstCall().returns(res);
+  callback = () => {
+    t.is(getStub.callCount, 1);
+    t.is(getStub.getCall(0).args[1], '/v1/genomic-ingestion/projects/projectId/ingestions/ingestionId');
+    t.is(printSpy.callCount, 1);
+    t.true(printSpy.calledWith({ id: 'ingestionId' }));
+    t.end();
+  };
+
+  yargs.command(get).parse('get projectId ingestionId');
+});
+
+test.serial.cb('The "list" command should return ingestions based on project id', t => {
+  const res = { data: { items: [] } };
+  getStub.onFirstCall().returns(res);
+  callback = () => {
+    t.is(getStub.callCount, 1);
+    t.is(getStub.getCall(0).args[1], '/v1/genomic-ingestion/projects/projectId/ingestions?pageSize=1&nextPageToken=token&name=foo&steps=Submitted');
+    t.is(printSpy.callCount, 1);
+    t.true(printSpy.calledWith({ items: [] }));
+    t.end();
+  };
+
+  yargs.command(list).parse('list projectId -n 1 -t token --name foo --failed false --step Submitted');
+});
+
+test.serial.cb('The "create-foundation" command should create a Foundation ingestion', t => {
+  const res = { data: { id: 'ingestionId' } };
+  postStub.onFirstCall().returns(res);
+  callback = () => {
+    t.is(postStub.callCount, 1);
+    t.is(postStub.getCall(0).args[1], '/v1/genomic-ingestion/projects/projectId/ingestions');
+    t.deepEqual(postStub.getCall(0).args[2], {
+      ingestionType: 'Foundation',
+      inputFiles: {
+        xml: 'xmlFileId',
+        vcf: 'vcfFileId',
+        report: 'reportFileId'
+      },
+      notificationConfig: {
+        succeededEmail: 'succeeded@test.com',
+        failedEmail: 'failed@test.com'
+      }
+    });
+    t.is(printSpy.callCount, 1);
+    t.true(printSpy.calledWith({ id: 'ingestionId' }));
+    t.end();
+  };
+
+  yargs.command(createFoundation).parse('create-foundation projectId xmlFileId reportFileId vcfFileId --succeededEmail succeeded@test.com --failedEmail failed@test.com');
+});
+
+test.serial.cb('The "create-caris" command should create a Caris ingestion', t => {
+  const res = { data: { id: 'ingestionId' } };
+  postStub.onFirstCall().returns(res);
+  callback = () => {
+    t.is(postStub.callCount, 1);
+    t.is(postStub.getCall(0).args[1], '/v1/genomic-ingestion/projects/projectId/ingestions');
+    t.deepEqual(postStub.getCall(0).args[2], {
+      ingestionType: 'Caris',
+      inputFiles: {
+        tar: 'tarFileId'
+      },
+      notificationConfig: {
+        succeededEmail: undefined,
+        failedEmail: undefined
+      }
+    });
+    t.is(printSpy.callCount, 1);
+    t.true(printSpy.calledWith({ id: 'ingestionId' }));
+    t.end();
+  };
+
+  yargs.command(createCaris).parse('create-caris projectId tarFileId');
+});
+
+test.serial.cb('The "create-foundation-bam" command should create a Foundation BAM ingestion', t => {
+  const res = { data: { id: 'ingestionId' } };
+  postStub.onFirstCall().returns(res);
+  callback = () => {
+    t.is(postStub.callCount, 1);
+    t.is(postStub.getCall(0).args[1], '/v1/genomic-ingestion/projects/projectId/ingestions');
+    t.deepEqual(postStub.getCall(0).args[2], {
+      ingestionType: 'FoundationBam',
+      inputFiles: {
+        bam: 'bamFileId'
+      },
+      notificationConfig: {
+        succeededEmail: undefined,
+        failedEmail: undefined
+      }
+    });
+    t.is(printSpy.callCount, 1);
+    t.true(printSpy.calledWith({ id: 'ingestionId' }));
+    t.end();
+  };
+
+  yargs.command(createFoundationBam).parse('create-foundation-bam projectId bamFileId');
+});
+
+test.serial.cb('The "create-caris-bam" command should create a Caris BAM ingestion', t => {
+  const res = { data: { id: 'ingestionId' } };
+  postStub.onFirstCall().returns(res);
+  callback = () => {
+    t.is(postStub.callCount, 1);
+    t.is(postStub.getCall(0).args[1], '/v1/genomic-ingestion/projects/projectId/ingestions');
+    t.deepEqual(postStub.getCall(0).args[2], {
+      ingestionType: 'CarisBam',
+      inputFiles: {
+        bam: 'bamFileId'
+      },
+      notificationConfig: {
+        succeededEmail: undefined,
+        failedEmail: undefined
+      }
+    });
+    t.is(printSpy.callCount, 1);
+    t.true(printSpy.calledWith({ id: 'ingestionId' }));
+    t.end();
+  };
+
+  yargs.command(createCarisBam).parse('create-caris-bam projectId bamFileId');
+});


### PR DESCRIPTION
Adds the following commands for the `/genomic-ingestion` API:

- `lo genomics ingestions get <projectId> <ingestionId>`: gets an ingestion based on id
- `lo genomics ingestions list <projectId>`: lists ingestions in a project, supports filters for `name`, `failed`, and `step`
- `lo genomics ingestions create-foundation <projectId> <xmlFileId> <reportFileId> [vcfFileId]`: creates a Foundation ingestion for the supplied files
- `lo genomics ingestions create-caris <projectId> <tarFileId>`: creates a Caris ingestion for the supplied TAR file
- `lo genomics ingestions create-foundation-bam <projectId> <bamFileId>`: creates a Foundation BAM ingestion for the supplied BAM file
- `lo genomics ingestions create-caris-bam <projectId> <bamFileId>`: creates a Caris BAM ingestion for the supplied BAM file