### PR TITLE
fix: Provide default `defaults` object

### DIFF
--- a/lib/interceptor/tokenProvider.js
+++ b/lib/interceptor/tokenProvider.js
@@ -8,7 +8,7 @@ const { tokenPost } = require('../oauth');
 async function getToken () {
   const environment = config.getEnvironment();
   let accessToken = config.get(`${environment}.tokens.accessToken`) || process.env.PHC_ACCESS_TOKEN;
-  const defaults = config.get(`${environment}.defaults`);
+  const defaults = config.get(`${environment}.defaults`) || {};
 
   if (!accessToken && !defaults.useClientCredentials && !defaults.useApiKey) {
     throw new Error(`Need to run 'lo auth' to get an access token for this command, or 'lo setup' to set API key or client credentials`);

--- a/test/unit/interceptor/tokenProvider.test.js
+++ b/test/unit/interceptor/tokenProvider.test.js
@@ -69,6 +69,25 @@ test.serial(`tokenProvider should set the request Authorization header with a to
   t.false(setSpy.called);
 });
 
+test.serial(`tokenProvider should set the request Authorization header with a token from the PHC_ACCESS_TOKEN env var if not configured`, async t => {
+  const token = jwt.sign({
+    sub: '1234',
+    iss: 'cognito',
+    token_use: 'access',
+    exp: 2000
+  }, 'secret');
+  getStub.withArgs('dev.tokens.accessToken').returns(null);
+  // defaults will not be present if `lo setup` has not been run
+  getStub.withArgs('dev.defaults').returns(null);
+  process.env.PHC_ACCESS_TOKEN = token;
+
+  const config = { headers: {} };
+  await tokenProvider(config);
+  t.is(config.headers.Authorization, `Bearer ${token}`);
+  t.false(postStub.called);
+  t.false(setSpy.called);
+});
+
 test.serial(`tokenProvider should set the request Authorization header with a token from config`, async t => {
   const token = jwt.sign({
     sub: '1234',


### PR DESCRIPTION
When `lo setup` has not been run (i.e. a non-interactive environment), then the configstore object will not exist. Environment variables and reasonable defaults need to be used in these cases.